### PR TITLE
[QUZ-69][FEATURE] 좋아요 구현

### DIFF
--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/LikeApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/LikeApi.kt
@@ -2,11 +2,11 @@ package com.grepp.quizy.quiz.api.like
 
 import com.grepp.quizy.common.api.ApiResponse
 import com.grepp.quizy.quiz.api.like.dto.LikeRequest
+import com.grepp.quizy.quiz.api.like.dto.LikeStatusResponse
 import com.grepp.quizy.quiz.domain.like.LikeService
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/quiz/likes")
@@ -18,5 +18,19 @@ class LikeApi(private val likeService: LikeService) {
     ): ApiResponse<Boolean> =
             ApiResponse.success(
                     likeService.toggleLike(request.toLike())
+            )
+
+    @GetMapping("/status")
+    fun isLiked(
+            @RequestParam userId: Long,
+            @RequestParam quizIds: List<Long>,
+    ): ApiResponse<List<LikeStatusResponse>> =
+            ApiResponse.success(
+                    likeService
+                            .isLikedIn(
+                                    UserId(userId),
+                                    quizIds.map { QuizId(it) },
+                            )
+                            .map { LikeStatusResponse.from(it) }
             )
 }

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/LikeApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/LikeApi.kt
@@ -1,0 +1,22 @@
+package com.grepp.quizy.quiz.api.like
+
+import com.grepp.quizy.common.api.ApiResponse
+import com.grepp.quizy.quiz.api.like.dto.LikeRequest
+import com.grepp.quizy.quiz.domain.like.LikeService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/quiz/likes")
+class LikeApi(private val likeService: LikeService) {
+
+    @PostMapping
+    fun toggleLike(
+            @RequestBody request: LikeRequest
+    ): ApiResponse<Boolean> =
+            ApiResponse.success(
+                    likeService.toggleLike(request.toLike())
+            )
+}

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/dto/LikeRequest.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/dto/LikeRequest.kt
@@ -1,0 +1,11 @@
+package com.grepp.quizy.quiz.api.like.dto
+
+import com.grepp.quizy.quiz.domain.like.Like
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
+
+data class LikeRequest(val quizId: Long, val userId: Long) {
+
+    fun toLike(): Like =
+            Like(quizId = QuizId(quizId), likerId = UserId(userId))
+}

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/dto/LikeStatusCheckRequest.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/dto/LikeStatusCheckRequest.kt
@@ -1,0 +1,13 @@
+package com.grepp.quizy.quiz.api.like.dto
+
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
+
+data class LikeStatusCheckRequest(
+        val userId: Long,
+        val quizIds: List<Long>,
+) {
+    fun toUserId() = UserId(userId)
+
+    fun toQuizIds() = quizIds.map { QuizId(it) }
+}

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/dto/LikeStatusResponse.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/dto/LikeStatusResponse.kt
@@ -1,0 +1,16 @@
+package com.grepp.quizy.quiz.api.like.dto
+
+import com.grepp.quizy.quiz.domain.like.LikeStatus
+
+data class LikeStatusResponse(
+        val quizId: Long,
+        val isLiked: Boolean,
+) {
+    companion object {
+        fun from(likeStatus: LikeStatus) =
+                LikeStatusResponse(
+                        likeStatus.quizId.value,
+                        likeStatus.isLiked,
+                )
+    }
+}

--- a/quiz-service/quiz-application/app-api/src/main/resources/application.yml
+++ b/quiz-service/quiz-application/app-api/src/main/resources/application.yml
@@ -4,6 +4,14 @@ spring:
       local: common, domain, infra
       dev: common, domain, infra
 
+server:
+  tomcat:
+    max-connections: 10000
+    accept-count: 1000
+    connection-timeout: 20000
+    threads:
+      max: 200
+
 management:
   endpoints:
     web:

--- a/quiz-service/quiz-domain/build.gradle.kts
+++ b/quiz-service/quiz-domain/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     api(project(":common"))
     implementation("org.springframework:spring-context")
+    implementation("org.springframework:spring-tx")
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/comment/CommentAppender.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/comment/CommentAppender.kt
@@ -1,12 +1,16 @@
 package com.grepp.quizy.quiz.domain.comment
 
 import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.quiz.QuizReader
+import com.grepp.quizy.quiz.domain.quiz.QuizUpdater
 import com.grepp.quizy.quiz.domain.useranswer.UserId
 import org.springframework.stereotype.Component
 
 @Component
 class CommentAppender(
-        private val commentRepository: CommentRepository
+        private val commentRepository: CommentRepository,
+        private val quizReader: QuizReader,
+        private val quizUpdater: QuizUpdater,
 ) {
     fun append(
             quizId: QuizId,
@@ -21,6 +25,9 @@ class CommentAppender(
                         parentCommentId = parentCommentId,
                         _content = content,
                 )
+        val quiz = quizReader.readWithLock(quizId)
+        quiz.increaseCommentCount()
+        quizUpdater.update(quiz)
         return commentRepository.save(comment)
     }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/comment/CommentService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/comment/CommentService.kt
@@ -3,6 +3,7 @@ package com.grepp.quizy.quiz.domain.comment
 import com.grepp.quizy.quiz.domain.quiz.QuizId
 import com.grepp.quizy.quiz.domain.useranswer.UserId
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class CommentService(
@@ -16,6 +17,7 @@ class CommentService(
         CommentUpdateUseCase,
         CommentDeleteUseCase {
 
+    @Transactional
     override fun createComment(
             quizId: QuizId,
             writerId: UserId,

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/Like.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/Like.kt
@@ -1,0 +1,6 @@
+package com.grepp.quizy.quiz.domain.like
+
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
+
+data class Like(val likerId: UserId, val quizId: QuizId) {}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeManager.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeManager.kt
@@ -1,0 +1,31 @@
+package com.grepp.quizy.quiz.domain.like
+
+import com.grepp.quizy.quiz.domain.quiz.QuizCache
+import org.springframework.stereotype.Component
+
+@Component
+class LikeManager(
+        private val likeRepository: LikeRepository,
+        private val quizCache: QuizCache,
+) {
+
+    fun toggleLike(like: Like): Boolean {
+        return if (!isLiked(like)) {
+            quizCache.cacheLike(like)
+            quizCache.increaseLikeCount(like.quizId)
+            likeRepository.save(like)
+            true
+        } else {
+            quizCache.deleteLike(like)
+            quizCache.decreaseLikeCount(like.quizId)
+            likeRepository.delete(like)
+            false
+        }
+    }
+
+    fun isLiked(like: Like): Boolean =
+            quizCache.isLikeCached(like)
+                    ?: likeRepository.exists(like).also { exists ->
+                        if (exists) quizCache.cacheLike(like)
+                    }
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeManager.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeManager.kt
@@ -1,6 +1,8 @@
 package com.grepp.quizy.quiz.domain.like
 
 import com.grepp.quizy.quiz.domain.quiz.QuizCache
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
 import org.springframework.stereotype.Component
 
 @Component
@@ -23,7 +25,16 @@ class LikeManager(
         }
     }
 
-    fun isLiked(like: Like): Boolean =
+    fun isLikedIn(
+            userId: UserId,
+            quizIds: List<QuizId>,
+    ): List<LikeStatus> {
+        return quizIds.map {
+            LikeStatus(it, isLiked(Like(userId, it)))
+        }
+    }
+
+    private fun isLiked(like: Like): Boolean =
             quizCache.isLikeCached(like)
                     ?: likeRepository.exists(like).also { exists ->
                         if (exists) quizCache.cacheLike(like)

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeRepository.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeRepository.kt
@@ -1,0 +1,9 @@
+package com.grepp.quizy.quiz.domain.like
+
+interface LikeRepository {
+    fun save(like: Like)
+
+    fun delete(like: Like)
+
+    fun exists(like: Like): Boolean
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeService.kt
@@ -1,5 +1,7 @@
 package com.grepp.quizy.quiz.domain.like
 
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
 import org.springframework.stereotype.Service
 
 @Service
@@ -9,7 +11,10 @@ class LikeService(private val likeManager: LikeManager) {
         return likeManager.toggleLike(like)
     }
 
-    fun isLiked(like: Like): Boolean {
-        return likeManager.isLiked(like)
+    fun isLikedIn(
+            userId: UserId,
+            quizIds: List<QuizId>,
+    ): List<LikeStatus> {
+        return likeManager.isLikedIn(userId, quizIds)
     }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeService.kt
@@ -1,0 +1,15 @@
+package com.grepp.quizy.quiz.domain.like
+
+import org.springframework.stereotype.Service
+
+@Service
+class LikeService(private val likeManager: LikeManager) {
+
+    fun toggleLike(like: Like): Boolean {
+        return likeManager.toggleLike(like)
+    }
+
+    fun isLiked(like: Like): Boolean {
+        return likeManager.isLiked(like)
+    }
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeStatus.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/like/LikeStatus.kt
@@ -1,0 +1,5 @@
+package com.grepp.quizy.quiz.domain.like
+
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+
+data class LikeStatus(val quizId: QuizId, val isLiked: Boolean) {}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/ABTest.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/ABTest.kt
@@ -10,7 +10,8 @@ private constructor(
         dateTime: DateTime = DateTime.init(),
         type: QuizType = QuizType.AB_TEST,
         id: QuizId = QuizId(0),
-) : Quiz(userId, type, content, id, dateTime) {
+        commentCount: Long = 0,
+) : Quiz(userId, type, content, id, dateTime, commentCount) {
 
     init {
         validateOptions(2)
@@ -26,12 +27,14 @@ private constructor(
                 content: QuizContent,
                 id: QuizId,
                 dateTime: DateTime,
+                commentCount: Long,
         ): ABTest {
             return ABTest(
                     userId = userId,
                     content = content,
                     id = id,
                     dateTime = dateTime,
+                    commentCount = commentCount,
             )
         }
     }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/MultipleChoiceQuiz.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/MultipleChoiceQuiz.kt
@@ -11,7 +11,10 @@ private constructor(
         dateTime: DateTime = DateTime.init(),
         type: QuizType = QuizType.MULTIPLE_CHOICE,
         id: QuizId = QuizId(0),
-) : Quiz(userId, type, content, id, dateTime), Answerable {
+        commentCount: Long = 0,
+) :
+        Quiz(userId, type, content, id, dateTime, commentCount),
+        Answerable {
 
     val answer: QuizAnswer
         get() = _answer
@@ -36,6 +39,7 @@ private constructor(
                 answer: QuizAnswer,
                 id: QuizId,
                 dateTime: DateTime,
+                commentCount: Long,
         ): MultipleChoiceQuiz {
             return MultipleChoiceQuiz(
                     userId = userId,
@@ -43,6 +47,7 @@ private constructor(
                     _answer = answer,
                     id = id,
                     dateTime = dateTime,
+                    commentCount = commentCount,
             )
         }
     }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/OXQuiz.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/OXQuiz.kt
@@ -11,7 +11,10 @@ private constructor(
         dateTime: DateTime = DateTime.init(),
         type: QuizType = QuizType.OX,
         id: QuizId = QuizId(0),
-) : Quiz(userId, type, content, id, dateTime), Answerable {
+        commentCount: Long = 0,
+) :
+        Quiz(userId, type, content, id, dateTime, commentCount),
+        Answerable {
 
     val answer: QuizAnswer
         get() = _answer
@@ -36,6 +39,7 @@ private constructor(
                 answer: QuizAnswer,
                 id: QuizId,
                 dateTime: DateTime,
+                commentCount: Long,
         ): OXQuiz {
             return OXQuiz(
                     userId = userId,
@@ -43,6 +47,7 @@ private constructor(
                     _answer = answer,
                     id = id,
                     dateTime = dateTime,
+                    commentCount = commentCount,
             )
         }
     }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/Quiz.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/Quiz.kt
@@ -10,9 +10,14 @@ abstract class Quiz(
         private var _content: QuizContent,
         val id: QuizId,
         val dateTime: DateTime,
+        private var _commentCount: Long,
 ) {
+
     val content: QuizContent
         get() = this._content
+
+    val commentCount: Long
+        get() = this._commentCount
 
     protected fun validateOptions(requiredSize: Int) {
         require(_content.options.size == requiredSize) {
@@ -28,5 +33,9 @@ abstract class Quiz(
 
     fun validateOwner(userId: UserId) {
         require(this.userId == userId) { QuizException.NoPermission }
+    }
+
+    fun increaseCommentCount() {
+        this._commentCount++
     }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizCache.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizCache.kt
@@ -1,0 +1,15 @@
+package com.grepp.quizy.quiz.domain.quiz
+
+import com.grepp.quizy.quiz.domain.like.Like
+
+interface QuizCache {
+    fun increaseLikeCount(quizId: QuizId): Long
+
+    fun decreaseLikeCount(quizId: QuizId): Long
+
+    fun cacheLike(like: Like)
+
+    fun deleteLike(like: Like)
+
+    fun isLikeCached(like: Like): Boolean?
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizReader.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizReader.kt
@@ -10,6 +10,11 @@ class QuizReader(private val quizRepository: QuizRepository) {
                 ?: throw QuizException.NotFound
     }
 
+    fun readWithLock(id: QuizId): Quiz {
+        return quizRepository.findByIdWithLock(id)
+                ?: throw QuizException.NotFound
+    }
+
     fun readTags(ids: List<QuizTagId>): List<QuizTag> {
         return quizRepository.findTagsByInId(ids)
     }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizRepository.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizRepository.kt
@@ -3,9 +3,9 @@ package com.grepp.quizy.quiz.domain.quiz
 interface QuizRepository {
     fun save(quiz: Quiz): Quiz
 
-    fun update(quiz: Quiz): Quiz
-
     fun findById(id: QuizId): Quiz?
+
+    fun findByIdWithLock(id: QuizId): Quiz?
 
     fun findTagsByNameIn(names: List<String>): List<QuizTag>
 

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizService.kt
@@ -32,6 +32,10 @@ class QuizService(
         )
     }
 
+    override fun toggleLike(id: QuizId, userId: UserId) {
+        TODO("Not yet implemented")
+    }
+
     // TODO: Pagination
     override fun getQuizTags(ids: List<QuizTagId>): List<QuizTag> {
         return quizReader.readTags(ids)

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizUpdateUseCase.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizUpdateUseCase.kt
@@ -9,4 +9,6 @@ interface QuizUpdateUseCase {
             updatedContent: QuizContent,
             updatedAnswer: QuizAnswer?,
     ): Quiz
+
+    fun toggleLike(id: QuizId, userId: UserId)
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizUpdater.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quiz/QuizUpdater.kt
@@ -18,6 +18,10 @@ class QuizUpdater(private val quizRepository: QuizRepository) {
             quiz.updateAnswer(updatedAnswer)
         }
 
-        return quizRepository.update(quiz)
+        return quizRepository.save(quiz)
+    }
+
+    fun update(quiz: Quiz) {
+        quizRepository.save(quiz)
     }
 }

--- a/quiz-service/quiz-infra/build.gradle.kts
+++ b/quiz-service/quiz-infra/build.gradle.kts
@@ -22,4 +22,11 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("mysql:mysql-connector-java:8.0.28")
+
+    //redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+    // shedlock - schedule lock
+    implementation("net.javacrumbs.shedlock:shedlock-spring:5.10.0")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0")
 }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/entity/LikeEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/entity/LikeEntity.kt
@@ -1,0 +1,33 @@
+package com.grepp.quizy.quiz.infra.like.entity
+
+import com.grepp.quizy.jpa.BaseTimeEntity
+import com.grepp.quizy.quiz.domain.like.Like
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.useranswer.UserId
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "likes")
+class LikeEntity(@EmbeddedId var id: LikeEntityId) :
+        BaseTimeEntity() {
+
+    fun toDomain() =
+            Like(
+                    likerId = UserId(id.userId),
+                    quizId = QuizId(id.quizId),
+            )
+
+    companion object {
+        fun from(domain: Like): LikeEntity {
+            return LikeEntity(
+                    id =
+                            LikeEntityId(
+                                    userId = domain.likerId.value,
+                                    quizId = domain.quizId.value,
+                            )
+            )
+        }
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/entity/LikeEntityId.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/entity/LikeEntityId.kt
@@ -1,0 +1,20 @@
+package com.grepp.quizy.quiz.infra.like.entity
+
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+import java.util.*
+
+@Embeddable
+class LikeEntityId(val userId: Long = 0, val quizId: Long = 0) :
+        Serializable {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LikeEntityId) return false
+
+        return userId == other.userId && quizId == other.quizId
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(userId, quizId)
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/repository/LikeJpaRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/repository/LikeJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.grepp.quizy.quiz.infra.like.repository
+
+import com.grepp.quizy.quiz.infra.like.entity.LikeEntity
+import com.grepp.quizy.quiz.infra.like.entity.LikeEntityId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LikeJpaRepository :
+        JpaRepository<LikeEntity, LikeEntityId> {}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/repository/LikeRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/like/repository/LikeRepositoryAdapter.kt
@@ -1,0 +1,26 @@
+package com.grepp.quizy.quiz.infra.like.repository
+
+import com.grepp.quizy.quiz.domain.like.Like
+import com.grepp.quizy.quiz.domain.like.LikeRepository
+import com.grepp.quizy.quiz.infra.like.entity.LikeEntity
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Repository
+@Transactional
+class LikeRepositoryAdapter(
+        private val likeJpaRepository: LikeJpaRepository
+) : LikeRepository {
+
+    override fun save(like: Like) {
+        likeJpaRepository.save(LikeEntity.from(like))
+    }
+
+    override fun delete(like: Like) {
+        likeJpaRepository.delete(LikeEntity.from(like))
+    }
+
+    override fun exists(like: Like): Boolean {
+        return likeJpaRepository.existsById(LikeEntity.from(like).id)
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/cache/QuizRedisCache.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/cache/QuizRedisCache.kt
@@ -1,0 +1,62 @@
+package com.grepp.quizy.quiz.infra.quiz.cache
+
+import com.grepp.quizy.quiz.domain.like.Like
+import com.grepp.quizy.quiz.domain.quiz.QuizCache
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.infra.quiz.repository.QuizJpaRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Duration
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class QuizRedisCache(
+        private val redisTemplate: StringRedisTemplate,
+        private val quizJpaRepository: QuizJpaRepository,
+) : QuizCache {
+
+    companion object {
+        public const val QUIZ_LIKE_KEY = "quiz:like:"
+        private const val EXPIRE_DAYS = 7L
+    }
+
+    override fun increaseLikeCount(quizId: QuizId): Long {
+        val countKey = "$QUIZ_LIKE_KEY${quizId.value}:count"
+        return redisTemplate.opsForValue().increment(countKey)?.also {
+            redisTemplate.expire(
+                    countKey,
+                    Duration.ofDays(EXPIRE_DAYS),
+            )
+        } ?: throw IllegalStateException("좋아요 수 증가 실패")
+    }
+
+    override fun decreaseLikeCount(quizId: QuizId): Long {
+        val countKey = "$QUIZ_LIKE_KEY${quizId.value}:count"
+        return redisTemplate.opsForValue().decrement(countKey)
+                ?: throw IllegalStateException("좋아요 수 감소 실패")
+    }
+
+    override fun cacheLike(like: Like) {
+        val userLikeKey =
+                "$QUIZ_LIKE_KEY${like.quizId.value}:${like.likerId.value}"
+        redisTemplate
+                .opsForValue()
+                .set(userLikeKey, "1", Duration.ofDays(EXPIRE_DAYS))
+    }
+
+    override fun deleteLike(like: Like) {
+        val userLikeKey =
+                "$QUIZ_LIKE_KEY${like.quizId.value}:${like.likerId.value}"
+        redisTemplate.delete(userLikeKey)
+    }
+
+    override fun isLikeCached(like: Like): Boolean? {
+        val userLikeKey =
+                "$QUIZ_LIKE_KEY${like.quizId.value}:${like.likerId.value}"
+        return redisTemplate.opsForValue().get(userLikeKey)?.let {
+            true
+        }
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/ABTestEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/ABTestEntity.kt
@@ -36,11 +36,13 @@ class ABTestEntity(
                         ),
                 id = QuizId(this.id),
                 dateTime = DateTime(this.createdAt, this.updatedAt),
+                commentCount = this.commentCount,
         )
     }
 
     override fun update(quiz: Quiz): QuizEntity {
         updateContent(quiz.content)
+        commentCount = quiz.commentCount
         return this
     }
 
@@ -67,6 +69,7 @@ class ABTestEntity(
                     .apply {
                         this.createdAt = quiz.dateTime.createdAt
                         this.updatedAt = quiz.dateTime.updatedAt
+                        this.commentCount = quiz.commentCount
                     }
         }
     }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/MultipleChoiceQuizEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/MultipleChoiceQuizEntity.kt
@@ -38,12 +38,14 @@ class MultipleChoiceQuizEntity(
                 answer = this.answer.toDomain(),
                 id = QuizId(this.id),
                 dateTime = DateTime(this.createdAt, this.updatedAt),
+                commentCount = this.commentCount,
         )
     }
 
     override fun update(quiz: Quiz): QuizEntity {
         val multipleChoiceQuiz = quiz as MultipleChoiceQuiz
         updateContent(quiz.content)
+        commentCount = quiz.commentCount
         answer = QuizAnswerVO.from(multipleChoiceQuiz.answer)
         return this
     }
@@ -72,6 +74,7 @@ class MultipleChoiceQuizEntity(
                     .apply {
                         this.createdAt = quiz.dateTime.createdAt
                         this.updatedAt = quiz.dateTime.updatedAt
+                        this.commentCount = quiz.commentCount
                     }
         }
     }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/OXQuizEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/OXQuizEntity.kt
@@ -38,12 +38,13 @@ class OXQuizEntity(
                 answer = answer.toDomain(),
                 id = QuizId(this.id),
                 dateTime = DateTime(this.createdAt, this.updatedAt),
+                commentCount = this.commentCount,
         )
     }
 
     override fun update(quiz: Quiz): QuizEntity {
         val oxQuiz = quiz as OXQuiz
-
+        commentCount = quiz.commentCount
         updateContent(quiz.content)
         answer = QuizAnswerVO.from(oxQuiz.answer)
         return this
@@ -73,6 +74,7 @@ class OXQuizEntity(
                     .apply {
                         this.createdAt = quiz.dateTime.createdAt
                         this.updatedAt = quiz.dateTime.updatedAt
+                        this.commentCount = quiz.commentCount
                     }
         }
     }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/QuizEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/entity/QuizEntity.kt
@@ -40,6 +40,8 @@ abstract class QuizEntity(
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         val id: Long = 0L,
+        val likeCount: Long = 0,
+        var commentCount: Long = 0,
 ) : BaseTimeEntity() {
 
     abstract fun toDomain(): Quiz

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizJpaBatchRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizJpaBatchRepository.kt
@@ -1,0 +1,6 @@
+package com.grepp.quizy.quiz.infra.quiz.repository
+
+interface QuizJpaBatchRepository {
+
+    fun batchUpdate(updates: Map<Long, Long>)
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizJpaBatchRepositoryImpl.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizJpaBatchRepositoryImpl.kt
@@ -1,0 +1,49 @@
+package com.grepp.quizy.quiz.infra.quiz.repository
+
+import jakarta.persistence.EntityManager
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class QuizJpaBatchRepositoryImpl(
+        private val entityManager: EntityManager
+) : QuizJpaBatchRepository {
+
+    override fun batchUpdate(updates: Map<Long, Long>) {
+        if (updates.isEmpty()) return
+
+        val batchSize = 1000
+        updates.entries.chunked(batchSize).forEach { batch ->
+            val queryString = buildBatchUpdateQuery(batch)
+
+            val query = entityManager.createQuery(queryString)
+
+            batch.forEach { (quizId, count) ->
+                query.setParameter("id_${quizId}", quizId)
+                query.setParameter("count_${quizId}", count)
+            }
+            query.setParameter("ids", batch.map { it.key })
+
+            query.executeUpdate()
+        }
+
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    private fun buildBatchUpdateQuery(
+            batch: List<Map.Entry<Long, Long>>
+    ): String {
+        return """
+        UPDATE QuizEntity q 
+        SET q.likeCount = q.likeCount + CASE q.id 
+            ${batch.joinToString("\n") {
+            "WHEN :id_${it.key} THEN :count_${it.key}"
+        }}
+            ELSE 0 
+        END,
+        q.updatedAt = CURRENT_TIMESTAMP
+        WHERE q.id IN :ids
+    """
+                .trimIndent()
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizJpaRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizJpaRepository.kt
@@ -1,13 +1,21 @@
 package com.grepp.quizy.quiz.infra.quiz.repository
 
 import com.grepp.quizy.quiz.infra.quiz.entity.QuizEntity
+import jakarta.persistence.LockModeType
+import java.util.*
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 
-interface QuizJpaRepository : JpaRepository<QuizEntity, Long> {
+interface QuizJpaRepository :
+        JpaRepository<QuizEntity, Long>, QuizJpaBatchRepository {
 
     @Query(
             "select exists(select 1 from UserAnswerEntity ua where ua.id.quizId = :value)"
     )
     fun existsUserAnswerByQuizId(value: Long): Boolean
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select q from QuizEntity q where q.id = :value")
+    fun findByIdWithLock(value: Long): Optional<QuizEntity>
 }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/repository/QuizRepositoryAdapter.kt
@@ -12,31 +12,21 @@ class QuizRepositoryAdapter(
         private val quizTagJpaRepository: QuizTagJpaRepository,
 ) : QuizRepository {
     override fun save(quiz: Quiz): Quiz {
-        val quizEntity =
-                when (quiz) {
-                    is ABTest -> ABTestEntity.from(quiz)
-                    is OXQuiz -> OXQuizEntity.from(quiz)
-                    is MultipleChoiceQuiz ->
-                            MultipleChoiceQuizEntity.from(quiz)
-                    else ->
-                            throw IllegalArgumentException(
-                                    "알 수 없는 퀴즈 타입입니다"
-                            )
-                }
-        return quizJpaRepository.save(quizEntity).toDomain()
-    }
-
-    override fun update(quiz: Quiz): Quiz {
-        val quizEntity =
-                quizJpaRepository
-                        .findById(quiz.id.value)
-                        .orElseThrow()
-        return quizEntity.update(quiz).toDomain()
+        return quizJpaRepository
+                .save(QuizEntity.from(quiz))
+                .toDomain()
     }
 
     override fun findById(id: QuizId): Quiz? {
         return quizJpaRepository
                 .findById(id.value)
+                .map { it.toDomain() }
+                .orElse(null)
+    }
+
+    override fun findByIdWithLock(id: QuizId): Quiz? {
+        return quizJpaRepository
+                .findByIdWithLock(id.value)
                 .map { it.toDomain() }
                 .orElse(null)
     }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/scheduled/QuizLikeSynchronizer.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/scheduled/QuizLikeSynchronizer.kt
@@ -1,0 +1,60 @@
+package com.grepp.quizy.quiz.infra.quiz.scheduled
+
+import com.grepp.quizy.quiz.infra.quiz.cache.QuizRedisCache.Companion.QUIZ_LIKE_KEY
+import com.grepp.quizy.quiz.infra.quiz.repository.QuizJpaRepository
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.data.redis.core.ScanOptions
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class QuizLikeSynchronizer(
+        private val redisTemplate: StringRedisTemplate,
+        private val quizJpaRepository: QuizJpaRepository,
+) {
+    companion object {
+        private const val SCHEDULED_FIXED_RATE = 10000L // 10초
+    }
+
+    @SchedulerLock(
+            name = "like_sync_lock",
+            lockAtMostFor = "PT9S",
+            lockAtLeastFor = "PT3S",
+    )
+    @Scheduled(fixedRate = SCHEDULED_FIXED_RATE)
+    fun synchronizeLikeCounts() {
+        val scanOptions =
+                ScanOptions.scanOptions()
+                        .match("$QUIZ_LIKE_KEY*:count")
+                        .count(100)
+                        .build()
+
+        val quizIdToCountMap = mutableMapOf<Long, Long>()
+        val keysToDelete = mutableListOf<String>()
+
+        redisTemplate.execute { connection ->
+            val cursor = connection.commands().scan(scanOptions)
+            cursor.use { c ->
+                while (c.hasNext()) {
+                    val key = String(c.next(), Charsets.UTF_8)
+                    val quizId =
+                            key.substring(
+                                            QUIZ_LIKE_KEY.length,
+                                            key.lastIndexOf(":count"),
+                                    )
+                                    .toLong()
+                    val count =
+                            redisTemplate
+                                    .opsForValue()
+                                    .get(key)
+                                    ?.toLongOrNull() ?: 0L
+                    quizIdToCountMap[quizId] = count
+                    keysToDelete.add(key)
+                }
+            }
+        }
+        quizJpaRepository.batchUpdate(quizIdToCountMap)
+        redisTemplate.delete(keysToDelete)
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/scheduled/SchedulingConfig.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quiz/scheduled/SchedulingConfig.kt
@@ -1,0 +1,43 @@
+package com.grepp.quizy.quiz.infra.quiz.scheduled
+
+import javax.sql.DataSource
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30M")
+class SchedulingConfig(
+        @Value("\${shedlock.name}")
+        private val shedlockTableName: String
+) {
+    @Bean
+    fun taskScheduler(): TaskScheduler {
+        return ThreadPoolTaskScheduler().apply {
+            poolSize = 1
+            threadNamePrefix = "scheduled-task-pool-"
+            setAwaitTerminationSeconds(30)
+            setWaitForTasksToCompleteOnShutdown(true)
+            initialize()
+        }
+    }
+
+    @Bean
+    fun lockProvider(dataSource: DataSource): LockProvider {
+        return JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withTableName(shedlockTableName)
+                        .withJdbcTemplate(JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        )
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/redis/RedisConfig.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/redis/RedisConfig.kt
@@ -1,0 +1,20 @@
+package com.grepp.quizy.quiz.infra.redis
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+
+@Configuration
+@EnableRedisRepositories(basePackages = ["com.grepp.quizy"])
+class RedisConfig(
+        @Value("\${redis.host}") private val host: String,
+        @Value("\${redis.port}") private val port: Int,
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory =
+            LettuceConnectionFactory(host, port)
+}

--- a/quiz-service/quiz-infra/src/main/resources/application-infra.yml
+++ b/quiz-service/quiz-infra/src/main/resources/application-infra.yml
@@ -15,10 +15,10 @@ spring:
       hibernate:
         show-sql: true
         format_sql: true
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql: trace
+#logging:
+#  level:
+#    org.hibernate.SQL: debug
+#    org.hibernate.type.descriptor.sql: trace
 
 shedlock:
   name: like_sync_lock

--- a/quiz-service/quiz-infra/src/main/resources/application-infra.yml
+++ b/quiz-service/quiz-infra/src/main/resources/application-infra.yml
@@ -20,6 +20,9 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
 
+shedlock:
+  name: like_sync_lock
+
 kafka:
   topic:
     quiz: quiz
@@ -54,6 +57,10 @@ kafka-consumer-config:
   max-partition-fetch-bytes-default: 1048576
   max-partition-fetch-bytes-boost-factor: 1
   poll-timeout-ms: 150
+
+redis:
+  host: localhost
+  port: 6379
 
 ---
 spring:


### PR DESCRIPTION
<!-- PR의 제목은 "[Jira 티켓 코드] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

- 동시성 이슈 redis를 통해 해결
- 검색 서비스와 동기화문제 역정규화와 스케쥴링을 통한 배치 업데이트로 해결
- 다중 서버에서 스케쥴링 shedlock으로 해결

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->


## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->

와 진짜 좋아요 하나 구현하는데 이렇게 오래 걸릴줄 몰랐습니다....

동시성, 동기화, 다중서버 환경 고려할게 너무 많네요.... 일단 해당 이슈들 해결한다고 해결하긴했는데 최선의 방법인지는 확신이 없습니다..

좋아요 동시성 문제는 redis INCR을 통해 해결했고 사용자가 좋아요를 누르면 redis에 10초동안 쌓이다가 스케쥴링 처리로 퀴즈 테이블에 배치 업데이트가 됩니다!

퀴즈 테이블이 업데이트되면 퀴즈 테이블을 바라보고있던 debezium이 update 이벤트를 발행해서 해당 이벤트를 검색서비스에서 처리해 동기화하는 구조입니다!

다중서버에서 동기화 스케쥴링이 각각 돌아가면 문제가 될거라고 생각해 mysql shedlock을 통해 한번만 실행되도록 보장했습니다... 너무 힘드네요..

+) 민혁님의 피드백으로 좋아요를 한 사람들은 set을 이용해 구현했습니다. 하지만 set의 size로 좋아요수를 동기화하면 10초마다 기존 like_count에 + 연산을 하는 batch update와 함께 다시 0으로 초기화해야하는데 set_size로 좋아요 수를 판단하면 좋아요한 사람들을 캐시에서 모두 날려야하는 상황이 발생해서 `좋아요 한 사람`과 `좋아요 수`는 각각 set과 key를 이용해 관리하도록했습니다!

+) 아래는 제가 고민했던 내용입니다

과제1 : 동시성 이슈없이 좋아요수를 해결한다 -> redis
과제2: HTTP 요청으로 매번 받아오는 로직의 성능 문제 해결

과제 2번이 좀 큰 문제였는데 해결 방법이 생각났다.

먼저 좋아요 수 같은 경우에는 동시성 이슈가 발생할 가능성이 높고 클라이언트에게 실시간성이 보장될 필요는 크게 없다고 판단했다. 

따라서 redis(싱글 스레드)의 count를 통해 좋아요 수를 올리고 주기적으로 퀴즈 서비스 내의 quizzes 테이블에 update(redis <-> 퀴즈 서비스내의 DB 동기화)를 한다. 이렇게 update가 될때마다 debezium이 CDC를 통해 update 이벤트를 카프카에 전송하게되고 검색 서비스는 이 이벤트를 받아 퀴즈 도큐먼트의 좋아요 수를 업데이트한다.

댓글 수는 동시성 이슈 발생 가능성이 낮기때문에 따로 redis로 관리하지않고 사용가 댓글을 달때마다 read lock을 걸어서 quiz를 가져온뒤에 commentCount를 업데이트 해준다. 이 트랜잭션이 끝나면 마찬가지로 CDC에 의해 업데이트 이벤트가 전송되고 검색서비스는 이를 처리해 commentCount를 업데이트한다.
