### PR TITLE
[QUZ-77][FEATURE] random mathcing game implement

### DIFF
--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/GameMatchingApi.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/GameMatchingApi.kt
@@ -1,0 +1,31 @@
+package com.grepp.quizy.game.api.game
+
+import com.grepp.quizy.common.api.ApiResponse
+import com.grepp.quizy.game.api.game.dto.GameResponse
+import com.grepp.quizy.game.api.game.dto.MatchingRequest
+import com.grepp.quizy.game.domain.GameMatchingService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/game/matching")
+class GameMatchingApi(
+    private val gameMatchingService: GameMatchingService,
+) {
+
+    // 매칭 서비스에서 요청을 받아 게임을 생성하고, 생성된 게임을 반환한다.
+    @PostMapping
+    fun createRandomGame(
+        @RequestBody request: MatchingRequest
+    ) = ApiResponse.success(
+        GameResponse.from(
+            gameMatchingService.create(
+                userIds = request.userIds,
+                subject = request.subject
+            )
+        )
+    )
+
+}

--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/GameMatchingApi.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/GameMatchingApi.kt
@@ -4,10 +4,13 @@ import com.grepp.quizy.common.api.ApiResponse
 import com.grepp.quizy.game.api.game.dto.GameResponse
 import com.grepp.quizy.game.api.game.dto.MatchingRequest
 import com.grepp.quizy.game.domain.GameMatchingService
+import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.security.Principal
 
 @RestController
 @RequestMapping("/api/game/matching")
@@ -27,5 +30,16 @@ class GameMatchingApi(
             )
         )
     )
+
+    @MessageMapping("/join/{gameId}")
+    fun joinRandomGame(
+        @DestinationVariable gameId: Long,
+        principal: Principal
+    ) {
+        gameMatchingService.join(
+            principal.name.toLong(),
+            gameId
+        )
+    }
 
 }

--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/dto/GameResponse.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/dto/GameResponse.kt
@@ -3,14 +3,14 @@ package com.grepp.quizy.game.api.game.dto
 import com.grepp.quizy.game.domain.Game
 
 class GameResponse(
-        private val id: Long,
-        private val inviteCode: String,
+    private val id: Long,
+    private val inviteCode: String?,
 ) {
     companion object {
         fun from(game: Game): GameResponse {
             return GameResponse(
-                    id = game.id,
-                    inviteCode = game.inviteCode.value,
+                id = game.id,
+                inviteCode = game.inviteCode?.value,
             )
         }
     }

--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/dto/MatchingRequest.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/game/dto/MatchingRequest.kt
@@ -1,0 +1,10 @@
+package com.grepp.quizy.game.api.game.dto
+
+import com.grepp.quizy.game.domain.GameSubject
+
+data class MatchingRequest(
+    val userIds: List<Long>,
+    val subject: GameSubject,
+) {
+
+}

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Game.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Game.kt
@@ -31,7 +31,7 @@ class Game(
         id = id,
         type = GameType.RANDOM,
         _setting = GameSetting(subject),
-        _players = Players(userIds.map { Player(id = it) }.toList()),
+        _players = Players(userIds.map { Player(id = it, _status = PlayerStatus.WAITING) }.toList()),
         inviteCode = null
     ) {
         validatePlayerCount(userIds)
@@ -71,6 +71,10 @@ class Game(
     fun join(userId: Long) {
         validateGameNotStarted()
         this._players = _players.add(Player(id = userId))
+    }
+
+    fun joinRandomGame(userId: Long) {
+        this._players = _players.joinRandomGame(userId)
     }
 
     fun quit(userId: Long) {

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Game.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Game.kt
@@ -128,4 +128,8 @@ class Game(
         }
     }
 
+    fun isReady(): Boolean {
+        return _players.isAllParticipated()
+    }
+
 }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Game.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Game.kt
@@ -2,15 +2,17 @@ package com.grepp.quizy.game.domain
 
 import com.grepp.quizy.game.domain.GameStatus.DELETED
 import com.grepp.quizy.game.domain.GameStatus.WAITING
+import com.grepp.quizy.game.domain.exception.GameException
 import com.grepp.quizy.game.domain.exception.GameException.GameAlreadyStartedException
 import com.grepp.quizy.game.domain.exception.GameException.GameHostPermissionException
 
 class Game(
     val id: Long = 0,
+    val type: GameType,
     private var _setting: GameSetting,
     private var _status: GameStatus = WAITING,
     private var _players: Players,
-    val inviteCode: InviteCode = InviteCode()
+    val inviteCode: InviteCode?
 ) {
     val setting: GameSetting
         get() = _setting
@@ -20,6 +22,20 @@ class Game(
 
     val status: GameStatus
         get() = _status
+
+    constructor(
+        id: Long,
+        subject: GameSubject,
+        userIds: List<Long>
+    ) : this(
+        id = id,
+        type = GameType.RANDOM,
+        _setting = GameSetting(subject),
+        _players = Players(userIds.map { Player(id = it) }.toList()),
+        inviteCode = null
+    ) {
+        validatePlayerCount(userIds)
+    }
 
     companion object {
         fun create(
@@ -31,10 +47,24 @@ class Game(
         ): Game {
             val game = Game(
                 id = id,
+                type = GameType.PRIVATE,
                 _setting = GameSetting(subject = subject, level = level, quizCount = quizCount),
-                _players = Players(listOf(Player(id = userId, _role = PlayerRole.HOST)))
+                _players = Players(listOf(Player(id = userId, _role = PlayerRole.HOST))),
+                inviteCode = InviteCode()
             )
             return game
+        }
+
+        fun random(
+            id: Long,
+            subject: GameSubject,
+            userIds: List<Long>
+        ): Game {
+            return Game(
+                id = id,
+                subject = subject,
+                userIds = userIds
+            )
         }
     }
 
@@ -46,7 +76,7 @@ class Game(
     fun quit(userId: Long) {
         val player = _players.findPlayerById(userId)
         this._players = _players.remove(player)
-        if(_players.isEmpty()) {
+        if (_players.isEmpty()) {
             _status = DELETED
         }
     }
@@ -85,6 +115,12 @@ class Game(
     private fun validateGameNotStarted() {
         if (status != WAITING) {
             throw GameAlreadyStartedException
+        }
+    }
+
+    private fun validatePlayerCount(userIds: List<Long>) {
+        if (userIds.size != 5) {
+            throw GameException.GameMisMatchNumberOfPlayersException
         }
     }
 

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameAppender.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameAppender.kt
@@ -4,24 +4,36 @@ import org.springframework.stereotype.Component
 
 @Component
 class GameAppender(
-        private val gameRepository: GameRepository,
-        private val idGenerator: IdGenerator,
+    private val gameRepository: GameRepository,
+    private val idGenerator: IdGenerator,
 ) {
 
     fun append(
-            userId: Long,
-            subject: GameSubject,
-            level: GameLevel,
-            quizCount: Int,
+        userId: Long,
+        subject: GameSubject,
+        level: GameLevel,
+        quizCount: Int,
     ): Game {
         val game =
-                Game.create(
-                        id = idGenerator.generate("game"),
-                        subject = subject,
-                        quizCount = quizCount,
-                        level = level,
-                        userId = userId,
-                )
+            Game.create(
+                id = idGenerator.generate("game"),
+                subject = subject,
+                quizCount = quizCount,
+                level = level,
+                userId = userId,
+            )
+        return gameRepository.save(game)
+    }
+
+    fun appendRandomGame(
+        userIds: List<Long>,
+        subject: GameSubject
+    ): Game {
+        val game = Game.random(
+            id = idGenerator.generate("game"),
+            subject = subject,
+            userIds = userIds
+        )
         return gameRepository.save(game)
     }
 }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameApplicationEvent.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameApplicationEvent.kt
@@ -1,0 +1,7 @@
+package com.grepp.quizy.game.domain
+
+class GameStartEvent(
+    val game: Game
+) {
+
+}

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameMatchingService.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameMatchingService.kt
@@ -5,12 +5,25 @@ import org.springframework.stereotype.Service
 @Service
 class GameMatchingService(
     private val gameAppender: GameAppender,
+    private val gameReader: GameReader,
+    private val messagePublisher: GameMessagePublisher
 ) {
 
     fun create(userIds: List<Long>, subject: GameSubject): Game {
         return gameAppender.appendRandomGame(
             userIds = userIds,
             subject = subject
+        )
+    }
+
+    fun join(userId: Long, gameId: Long) {
+        val game = gameReader.read(gameId)
+        game.joinRandomGame(userId)
+        messagePublisher.publish(
+            GameMessage.room(
+                game.id,
+                RoomPayload.from(game),
+            )
         )
     }
 

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameMatchingService.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameMatchingService.kt
@@ -1,12 +1,14 @@
 package com.grepp.quizy.game.domain
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class GameMatchingService(
     private val gameAppender: GameAppender,
     private val gameReader: GameReader,
-    private val messagePublisher: GameMessagePublisher
+    private val messagePublisher: GameMessagePublisher,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
 
     fun create(userIds: List<Long>, subject: GameSubject): Game {
@@ -25,6 +27,9 @@ class GameMatchingService(
                 RoomPayload.from(game),
             )
         )
+        if (game.isReady()) {
+            eventPublisher.publishEvent(GameStartEvent(game))
+        }
     }
 
 }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameMatchingService.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameMatchingService.kt
@@ -1,0 +1,17 @@
+package com.grepp.quizy.game.domain
+
+import org.springframework.stereotype.Service
+
+@Service
+class GameMatchingService(
+    private val gameAppender: GameAppender,
+) {
+
+    fun create(userIds: List<Long>, subject: GameSubject): Game {
+        return gameAppender.appendRandomGame(
+            userIds = userIds,
+            subject = subject
+        )
+    }
+
+}

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GamePrivateService.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GamePrivateService.kt
@@ -4,24 +4,24 @@ import org.springframework.stereotype.Service
 
 @Service
 class GamePrivateService(
-        private val gameAppender: GameAppender,
-        private val gameReader: GameReader,
-        private val gamePlayerManager: GamePlayerManager,
-        private val gameSettingManager: GameSettingManager,
-        private val messagePublisher: GameMessagePublisher,
+    private val gameAppender: GameAppender,
+    private val gameReader: GameReader,
+    private val gamePlayerManager: GamePlayerManager,
+    private val gameSettingManager: GameSettingManager,
+    private val messagePublisher: GameMessagePublisher,
 ) {
 
     fun create(
-            userId: Long,
-            subject: GameSubject,
-            level: GameLevel,
-            quizCount: Int,
+        userId: Long,
+        subject: GameSubject,
+        level: GameLevel,
+        quizCount: Int,
     ): Game {
         return gameAppender.append(
-                userId = userId,
-                subject = subject,
-                level = level,
-                quizCount = quizCount,
+            userId = userId,
+            subject = subject,
+            level = level,
+            quizCount = quizCount,
         )
     }
 
@@ -29,10 +29,10 @@ class GamePrivateService(
         val game = gameReader.readByInviteCode(code)
         val currentGame = gamePlayerManager.join(game, userId)
         messagePublisher.publish(
-                GameMessage.room(
-                        currentGame.id,
-                        GamePayload.from(currentGame),
-                )
+            GameMessage.room(
+                currentGame.id,
+                RoomPayload.from(currentGame),
+            )
         )
         return currentGame
     }
@@ -41,42 +41,42 @@ class GamePrivateService(
         val game = gameReader.read(gameId)
         val currentGame = gamePlayerManager.quit(game, userId)
         messagePublisher.publish(
-                GameMessage.room(
-                        currentGame.id,
-                        GamePayload.from(currentGame),
-                )
+            GameMessage.room(
+                currentGame.id,
+                RoomPayload.from(currentGame),
+            )
         )
     }
 
     fun updateSubject(
-            userId: Long,
-            gameId: Long,
-            subject: GameSubject,
+        userId: Long,
+        gameId: Long,
+        subject: GameSubject,
     ) {
         val game = gameReader.read(gameId)
         val currentGame =
-                gameSettingManager.updateSubject(
-                        game,
-                        subject,
-                        userId,
-                )
+            gameSettingManager.updateSubject(
+                game,
+                subject,
+                userId,
+            )
         messagePublisher.publish(
-                GameMessage.room(
-                        currentGame.id,
-                        GamePayload.from(currentGame),
-                )
+            GameMessage.room(
+                currentGame.id,
+                RoomPayload.from(currentGame),
+            )
         )
     }
 
     fun updateLevel(userId: Long, gameId: Long, level: GameLevel) {
         val game = gameReader.read(gameId)
         val currentGame =
-                gameSettingManager.updateLevel(game, level, userId)
+            gameSettingManager.updateLevel(game, level, userId)
         messagePublisher.publish(
-                GameMessage.room(
-                        currentGame.id,
-                        GamePayload.from(currentGame),
-                )
+            GameMessage.room(
+                currentGame.id,
+                RoomPayload.from(currentGame),
+            )
         )
     }
 
@@ -86,7 +86,7 @@ class GamePrivateService(
         messagePublisher.publish(
             GameMessage.room(
                 currentGame.id,
-                GamePayload.from(currentGame)
+                RoomPayload.from(currentGame)
             )
         )
     }
@@ -94,12 +94,12 @@ class GamePrivateService(
     fun kickUser(userId: Long, gameId: Long, targetUserId: Long) {
         val game = gameReader.read(gameId)
         val currentGame =
-                gamePlayerManager.kick(game, userId, targetUserId)
+            gamePlayerManager.kick(game, userId, targetUserId)
         messagePublisher.publish(
-                GameMessage.room(
-                        currentGame.id,
-                        GamePayload.from(currentGame),
-                )
+            GameMessage.room(
+                currentGame.id,
+                RoomPayload.from(currentGame),
+            )
         )
     }
 }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameQuiz.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameQuiz.kt
@@ -1,0 +1,23 @@
+package com.grepp.quizy.game.domain
+
+data class GameQuiz(
+    val id: Long,
+    val content: String,
+    val option: List<GameQuizOption>,
+    val answer: GameQuizAnswer
+) {
+}
+
+data class GameQuizOption(
+    val optionNumber: Int,
+    val content: String
+) {
+
+}
+
+data class GameQuizAnswer(
+    val content: String,
+    val explanation: String
+) {
+
+}

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameVO.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameVO.kt
@@ -190,5 +190,11 @@ data class Players(
         return players.isEmpty()
     }
 
+    fun isAllParticipated(): Boolean {
+        return players.map {
+            it.isWaiting()
+        }.all { !it }
+    }
+
 
 }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameVO.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/GameVO.kt
@@ -2,6 +2,14 @@ package com.grepp.quizy.game.domain
 
 import com.grepp.quizy.game.domain.exception.GameException
 
+enum class GameType(
+    val description: String
+) {
+    PRIVATE("사설 게임"),
+    RANDOM("랜덤 매칭 게임"),
+    ;
+}
+
 enum class GameStatus(
     val description: String
 ) {
@@ -16,8 +24,8 @@ enum class GameStatus(
 
 data class GameSetting(
     val subject: GameSubject,
-    val level: GameLevel,
-    val quizCount: Int,
+    val level: GameLevel = GameLevel.RANDOM,
+    val quizCount: Int = 10,
 ) {
     fun updateSubject(subject: GameSubject): GameSetting {
         return copy(subject = subject)
@@ -50,6 +58,7 @@ enum class GameLevel(
     EASY("쉬움"),
     NORMAL("보통"),
     HARD("어려움"),
+    RANDOM("랜덤")
 
     ;
 }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Message.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/Message.kt
@@ -25,6 +25,7 @@ data class GameMessage(
                 payload = payload,
             )
         }
+
         fun chat(gameId: Long, payload: MessagePayload): GameMessage {
             return GameMessage(
                 gameId = gameId,
@@ -35,19 +36,19 @@ data class GameMessage(
     }
 }
 
-data class GamePayload(
+data class RoomPayload(
     val setting: GameSetting,
     val status: GameStatus,
     val players: Players,
-    val inviteCode: InviteCode,
+    val inviteCode: InviteCode?,
 ) : MessagePayload {
     companion object {
-        fun from(game: Game): GamePayload {
-            return GamePayload(
-                setting = game.setting,
-                status = game.status,
-                players = game.players,
-                inviteCode = game.inviteCode,
+        fun from(game: Game): RoomPayload {
+            return RoomPayload(
+                game.setting,
+                game.status,
+                game.players,
+                game.inviteCode,
             )
         }
     }

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/QuizFetcher.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/QuizFetcher.kt
@@ -1,0 +1,11 @@
+package com.grepp.quizy.game.domain
+
+interface QuizFetcher {
+
+    fun fetchQuiz(
+        subject: GameSubject,
+        quizCount: Int,
+        level: GameLevel
+    ): GameQuiz
+
+}

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/exception/GameErrorCode.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/exception/GameErrorCode.kt
@@ -4,9 +4,9 @@ import com.grepp.quizy.common.exception.BaseErrorCode
 import com.grepp.quizy.common.exception.ErrorReason
 
 enum class GameErrorCode(
-        private val status: Int,
-        private val errorCode: String,
-        private val message: String,
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
 ) : BaseErrorCode {
 
     GAME_NOT_FOUND(404, "G001", "해당 게임을 찾지 못했습니다."),
@@ -27,19 +27,22 @@ enum class GameErrorCode(
     GAME_INVALID_PLAYER_RANK(409, "G016", "유효하지 않은 참가자 순위입니다."),
     GAME_INVALID_PLAYER_RANKING(409, "G017", "유효하지 않은 참가자 순위 목록입니다."),
     GAME_INVALID_PLAYER_RANKING_SIZE(
-            409,
-            "G018",
-            "유효하지 않은 참가자 순위 목록 크기입니다.",
+        409,
+        "G018",
+        "유효하지 않은 참가자 순위 목록 크기입니다.",
     ),
     GAME_INVALID_PLAYER_RANKING_SCORE(
-            409,
-            "G019",
-            "유효하지 않은 참가자 순위 목록 점수입니다.",
+        409,
+        "G019",
+        "유효하지 않은 참가자 순위 목록 점수입니다.",
     ),
     GAME_ALREADY_PARTICIPATED(409, "G020", "이미 참가한 게임입니다."),
     GAME_PARTICIPANT_ALREADY_FULL(409, "G021", "게임 대기 인원이 꽉 찼습니다."),
     GAME_NOT_PARTICIPATED(409, "G022", "참가하지 않은 게임입니다."),
-    GAME_HOST_PERMISSION(409, "G023", "게임 방장만 가능한 작업입니다.");
+    GAME_HOST_PERMISSION(409, "G023", "게임 방장만 가능한 작업입니다."),
+    GAME_MISMATCH_NUMBER_OF_PLAYERS(409, "G024", "참가자 수가 일치하지 않습니다."),
+
+    ;
 
     override val errorReason: ErrorReason
         get() = ErrorReason.of(status, errorCode, message)

--- a/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/exception/GameException.kt
+++ b/game-service/game-domain/src/main/kotlin/com/grepp/quizy/game/domain/exception/GameException.kt
@@ -3,25 +3,28 @@ package com.grepp.quizy.game.domain.exception
 import com.grepp.quizy.common.exception.DomainException
 
 sealed class GameException(errorCode: GameErrorCode) :
-        DomainException(errorCode) {
+    DomainException(errorCode) {
 
     data object GameNotFoundException :
-            GameException(GameErrorCode.GAME_NOT_FOUND)
+        GameException(GameErrorCode.GAME_NOT_FOUND)
 
     data object GameAlreadyParticipatedException :
-            GameException(GameErrorCode.GAME_ALREADY_PARTICIPATED)
+        GameException(GameErrorCode.GAME_ALREADY_PARTICIPATED)
 
     data object GameAlreadyStartedException :
-            GameException(GameErrorCode.GAME_ALREADY_STARTED)
+        GameException(GameErrorCode.GAME_ALREADY_STARTED)
 
     data object GameAlreadyFullException :
-            GameException(
-                    GameErrorCode.GAME_PARTICIPANT_ALREADY_FULL
-            )
+        GameException(
+            GameErrorCode.GAME_PARTICIPANT_ALREADY_FULL
+        )
 
     data object GameNotParticipatedException :
-            GameException(GameErrorCode.GAME_NOT_PARTICIPATED)
+        GameException(GameErrorCode.GAME_NOT_PARTICIPATED)
 
     data object GameHostPermissionException :
-            GameException(GameErrorCode.GAME_HOST_PERMISSION)
+        GameException(GameErrorCode.GAME_HOST_PERMISSION)
+
+    data object GameMisMatchNumberOfPlayersException :
+        GameException(GameErrorCode.GAME_MISMATCH_NUMBER_OF_PLAYERS)
 }

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/FakeGameApplicationEventPublisher.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/FakeGameApplicationEventPublisher.kt
@@ -1,0 +1,21 @@
+package com.grepp.quizy.game.domain
+
+import org.springframework.context.ApplicationEventPublisher
+
+class FakeGameApplicationEventPublisher : ApplicationEventPublisher {
+
+    private val events = mutableListOf<Any>()
+
+    override fun publishEvent(event: Any) {
+        events.add(event)
+    }
+
+    fun getEvents(): List<Any> {
+        return events
+    }
+
+    fun clear() {
+        events.clear()
+    }
+
+}

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/FakeGameRepository.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/FakeGameRepository.kt
@@ -12,6 +12,7 @@ class FakeGameRepository : GameRepository {
         val savedGame = if (game.id == 0L) {
             Game(
                 id = sequence.incrementAndGet(),
+                type = game.type,
                 inviteCode = game.inviteCode,
                 _setting = game.setting,
                 _status = game.status,
@@ -29,7 +30,7 @@ class FakeGameRepository : GameRepository {
     }
 
     override fun findByInviteCode(code: String): Game? {
-        return games.values.find { it.inviteCode.value == code }
+        return games.values.find { it.inviteCode?.value == code }
     }
 
     fun clear() {

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameAppenderTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameAppenderTest.kt
@@ -30,7 +30,27 @@ class GameAppenderTest(
                 appendedGame.players.players.size shouldBe 1
                 appendedGame.players.players[0].id shouldBe 1L
                 appendedGame.players.players[0].role shouldBe PlayerRole.HOST
-                appendedGame.inviteCode.value.length shouldBe 6
+                appendedGame.inviteCode!!.value.length shouldBe 6
+            }
+        }
+        context("랜덤 게임을 추가하면") {
+            it("랜덤 게임이 생성된다.") {
+                val randomGame = gameAppender.appendRandomGame(
+                    listOf(
+                        1L,
+                        2L,
+                        3L,
+                        4L,
+                        5L
+                    ), GameSubject.SPRING
+                )
+
+                randomGame.id shouldBe randomGame.id
+                randomGame.setting.subject shouldBe GameSubject.SPRING
+                randomGame.setting.level shouldBe GameLevel.RANDOM
+                randomGame.setting.quizCount shouldBe 10
+                randomGame.status shouldBe GameStatus.WAITING
+                randomGame.players.players.size shouldBe 5
             }
         }
     }

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameMatchingServiceTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameMatchingServiceTest.kt
@@ -6,8 +6,12 @@ import io.kotest.matchers.shouldBe
 class GameMatchingServiceTest() : DescribeSpec({
     val gameRepository = FakeGameRepository()
     val idGenerator = FakeIdGenerator()
+
     val gameAppender = GameAppender(gameRepository, idGenerator)
-    val matchingService = GameMatchingService(gameAppender)
+    val gameReader = GameReader(gameRepository)
+    val messagePublisher = FakeGameMessagePublisher()
+
+    val matchingService = GameMatchingService(gameAppender, gameReader, messagePublisher)
 
     afterTest {
         gameRepository.clear()
@@ -31,7 +35,34 @@ class GameMatchingServiceTest() : DescribeSpec({
 
             }
         }
-    }
-}) {
+        context("게임에 참여하면") {
+            it("참여를 확인한다") {
+                val randomGame = generateRandomGameFixture(gameRepository)
 
-}
+                matchingService.join(1L, randomGame.id)
+
+                messagePublisher.getMessages().size shouldBe 1
+                val gameMessage = messagePublisher.getMessages().first()
+                gameMessage.gameId shouldBe randomGame.id
+                gameMessage.type shouldBe MessageType.GAME_ROOM
+
+                val roomPayload = gameMessage.payload as RoomPayload
+                roomPayload.setting.subject shouldBe GameSubject.SPRING
+                roomPayload.setting.level shouldBe GameLevel.RANDOM
+                roomPayload.setting.quizCount shouldBe 10
+                roomPayload.status shouldBe GameStatus.WAITING
+
+            }
+        }
+    }
+})
+
+private fun generateRandomGameFixture(
+    gameRepository: FakeGameRepository
+) = gameRepository.save(
+    Game.random(
+        id = 1,
+        subject = GameSubject.SPRING,
+        userIds = listOf(1L, 2L, 3L, 4L, 5L)
+    )
+)

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameMatchingServiceTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameMatchingServiceTest.kt
@@ -1,0 +1,37 @@
+package com.grepp.quizy.game.domain
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class GameMatchingServiceTest() : DescribeSpec({
+    val gameRepository = FakeGameRepository()
+    val idGenerator = FakeIdGenerator()
+    val gameAppender = GameAppender(gameRepository, idGenerator)
+    val matchingService = GameMatchingService(gameAppender)
+
+    afterTest {
+        gameRepository.clear()
+        idGenerator.reset()
+    }
+
+    describe("GameMatchingService") {
+        context("게임을 생성하면") {
+            it("게임이 생성된다.") {
+                val game = matchingService.create(
+                    listOf(1L, 2L, 3L, 4L, 5L),
+                    GameSubject.SPRING
+                )
+
+                game.id shouldBe game.id
+                game.setting.subject shouldBe GameSubject.SPRING
+                game.setting.level shouldBe GameLevel.RANDOM
+                game.setting.quizCount shouldBe 10
+                game.status shouldBe GameStatus.WAITING
+                game.players.players.size shouldBe 5
+
+            }
+        }
+    }
+}) {
+
+}

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GamePlayerManagerTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GamePlayerManagerTest.kt
@@ -1,5 +1,6 @@
 package com.grepp.quizy.game.domain
 
+import com.grepp.quizy.game.domain.GameType.PRIVATE
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
@@ -59,6 +60,7 @@ class GamePlayerManagerTest() : DescribeSpec({
 
 private fun generateGameFixture(gameRepository: FakeGameRepository): Game {
     val game = Game(
+        type = PRIVATE,
         _setting = GameSetting(
             subject = GameSubject.SPRING,
             level = GameLevel.EASY,

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GamePrivateServiceTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GamePrivateServiceTest.kt
@@ -1,9 +1,10 @@
 package com.grepp.quizy.game.domain
 
+import com.grepp.quizy.game.domain.GameType.PRIVATE
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.*
+import io.kotest.matchers.shouldBe
 
-class GameServiceTest() : DescribeSpec({
+class GamePrivateServiceTest() : DescribeSpec({
     val gameRepository = FakeGameRepository()
     val idGenerator = FakeIdGenerator()
     val gameMessagePublisher = FakeGameMessagePublisher()
@@ -45,7 +46,7 @@ class GameServiceTest() : DescribeSpec({
                 createdGame.players.players.size shouldBe 1
                 createdGame.players.players[0].id shouldBe 1L
                 createdGame.players.players[0].role shouldBe PlayerRole.HOST
-                createdGame.inviteCode.value.length shouldBe 6
+                createdGame.inviteCode!!.value.length shouldBe 6
 
             }
         }
@@ -67,7 +68,7 @@ class GameServiceTest() : DescribeSpec({
                 publishedMessage.type shouldBe MessageType.GAME_ROOM
 
                 // GamePayload 검증
-                val payload = gameMessagePublisher.getMessages().first().payload as GamePayload
+                val payload = gameMessagePublisher.getMessages().first().payload as RoomPayload
 
                 payload.setting.subject shouldBe GameSubject.SPRING
                 payload.setting.level shouldBe GameLevel.EASY
@@ -80,7 +81,7 @@ class GameServiceTest() : DescribeSpec({
                 payload.players.players[1].role shouldBe PlayerRole.GUEST
                 payload.players.players[2].id shouldBe 3L
                 payload.players.players[2].role shouldBe PlayerRole.GUEST
-                payload.inviteCode.value shouldBe "ABC123"
+                payload.inviteCode!!.value shouldBe "ABC123"
 
             }
         }
@@ -88,7 +89,7 @@ class GameServiceTest() : DescribeSpec({
             it("게임에서 사용자가 제거된다.") {
                 val game = generateGameFixture(gameRepository)
 
-                gamePrivateService.quit(2,game.id)
+                gamePrivateService.quit(2, game.id)
 
                 // 메시지 검증
                 gameMessagePublisher.getMessages().size shouldBe 1
@@ -97,7 +98,7 @@ class GameServiceTest() : DescribeSpec({
                 publishedMessage.type shouldBe MessageType.GAME_ROOM
 
                 // GamePayload 검증
-                val payload = gameMessagePublisher.getMessages().first().payload as GamePayload
+                val payload = gameMessagePublisher.getMessages().first().payload as RoomPayload
 
                 payload.setting.subject shouldBe GameSubject.SPRING
                 payload.setting.level shouldBe GameLevel.EASY
@@ -106,7 +107,7 @@ class GameServiceTest() : DescribeSpec({
                 payload.players.players.size shouldBe 1
                 payload.players.players[0].id shouldBe 1L
                 payload.players.players[0].role shouldBe PlayerRole.HOST
-                payload.inviteCode.value shouldBe "ABC123"
+                payload.inviteCode!!.value shouldBe "ABC123"
             }
         }
         context("게임 주제를 변경하면") {
@@ -122,7 +123,7 @@ class GameServiceTest() : DescribeSpec({
                 publishedMessage.type shouldBe MessageType.GAME_ROOM
 
                 // GamePayload 검증
-                val payload = gameMessagePublisher.getMessages().first().payload as GamePayload
+                val payload = gameMessagePublisher.getMessages().first().payload as RoomPayload
 
                 payload.setting.subject shouldBe GameSubject.JAVASCRIPT
                 payload.setting.level shouldBe GameLevel.EASY
@@ -133,7 +134,7 @@ class GameServiceTest() : DescribeSpec({
                 payload.players.players[0].role shouldBe PlayerRole.HOST
                 payload.players.players[1].id shouldBe 2L
                 payload.players.players[1].role shouldBe PlayerRole.GUEST
-                payload.inviteCode.value shouldBe "ABC123"
+                payload.inviteCode!!.value shouldBe "ABC123"
             }
         }
         context("게임 난이도를 변경하면") {
@@ -149,7 +150,7 @@ class GameServiceTest() : DescribeSpec({
                 publishedMessage.type shouldBe MessageType.GAME_ROOM
 
                 // GamePayload 검증
-                val payload = gameMessagePublisher.getMessages().first().payload as GamePayload
+                val payload = gameMessagePublisher.getMessages().first().payload as RoomPayload
 
                 payload.setting.subject shouldBe GameSubject.SPRING
                 payload.setting.level shouldBe GameLevel.HARD
@@ -160,7 +161,7 @@ class GameServiceTest() : DescribeSpec({
                 payload.players.players[0].role shouldBe PlayerRole.HOST
                 payload.players.players[1].id shouldBe 2L
                 payload.players.players[1].role shouldBe PlayerRole.GUEST
-                payload.inviteCode.value shouldBe "ABC123"
+                payload.inviteCode!!.value shouldBe "ABC123"
             }
         }
         context("게임 퀴즈 수를 변경하면") {
@@ -176,7 +177,7 @@ class GameServiceTest() : DescribeSpec({
                 publishedMessage.type shouldBe MessageType.GAME_ROOM
 
                 // GamePayload 검증
-                val payload = gameMessagePublisher.getMessages().first().payload as GamePayload
+                val payload = gameMessagePublisher.getMessages().first().payload as RoomPayload
 
                 payload.setting.subject shouldBe GameSubject.SPRING
                 payload.setting.level shouldBe GameLevel.EASY
@@ -187,7 +188,7 @@ class GameServiceTest() : DescribeSpec({
                 payload.players.players[0].role shouldBe PlayerRole.HOST
                 payload.players.players[1].id shouldBe 2L
                 payload.players.players[1].role shouldBe PlayerRole.GUEST
-                payload.inviteCode.value shouldBe "ABC123"
+                payload.inviteCode!!.value shouldBe "ABC123"
             }
         }
         context("사용자를 강퇴하면") {
@@ -203,7 +204,7 @@ class GameServiceTest() : DescribeSpec({
                 publishedMessage.type shouldBe MessageType.GAME_ROOM
 
                 // GamePayload 검증
-                val payload = gameMessagePublisher.getMessages().first().payload as GamePayload
+                val payload = gameMessagePublisher.getMessages().first().payload as RoomPayload
 
                 payload.setting.subject shouldBe GameSubject.SPRING
                 payload.setting.level shouldBe GameLevel.EASY
@@ -212,7 +213,7 @@ class GameServiceTest() : DescribeSpec({
                 payload.players.players.size shouldBe 1
                 payload.players.players[0].id shouldBe 1L
                 payload.players.players[0].role shouldBe PlayerRole.HOST
-                payload.inviteCode.value shouldBe "ABC123"
+                payload.inviteCode!!.value shouldBe "ABC123"
             }
         }
     }
@@ -221,6 +222,7 @@ class GameServiceTest() : DescribeSpec({
 
 private fun generateGameFixture(gameRepository: FakeGameRepository) = gameRepository.save(
     Game(
+        type = PRIVATE,
         _setting = GameSetting(
             subject = GameSubject.SPRING,
             level = GameLevel.EASY,

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameReaderTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameReaderTest.kt
@@ -1,5 +1,6 @@
 package com.grepp.quizy.game.domain
 
+import com.grepp.quizy.game.domain.GameType.PRIVATE
 import com.grepp.quizy.game.domain.exception.GameException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
@@ -12,6 +13,7 @@ class GameReaderTest() : DescribeSpec({
 
     beforeTest {
         val game = Game(
+            type = PRIVATE,
             _setting = GameSetting(
                 subject = GameSubject.SPRING,
                 level = GameLevel.EASY,
@@ -55,7 +57,7 @@ class GameReaderTest() : DescribeSpec({
                     foundGame.players.players[0].role shouldBe PlayerRole.HOST
                     foundGame.players.players[1].id shouldBe 2
                     foundGame.players.players[1].role shouldBe PlayerRole.GUEST
-                    foundGame.inviteCode.value shouldBe "ABC123"
+                    foundGame.inviteCode!!.value shouldBe "ABC123"
                 }
             }
             context("게임이 존재하지 않으면") {
@@ -79,7 +81,7 @@ class GameReaderTest() : DescribeSpec({
                     foundGame.players.players[0].role shouldBe PlayerRole.HOST
                     foundGame.players.players[1].id shouldBe 2
                     foundGame.players.players[1].role shouldBe PlayerRole.GUEST
-                    foundGame.inviteCode.value shouldBe "ABC123"
+                    foundGame.inviteCode!!.value shouldBe "ABC123"
                 }
             }
             context("게임이 존재하지 않으면") {

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameSettingManagerTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameSettingManagerTest.kt
@@ -1,5 +1,6 @@
 package com.grepp.quizy.game.domain
 
+import com.grepp.quizy.game.domain.GameType.PRIVATE
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
@@ -51,6 +52,7 @@ class GameSettingManagerTest() : DescribeSpec({
 
 private fun generateGameFixture(gameRepository: FakeGameRepository): Game {
     val game = Game(
+        type = PRIVATE,
         _setting = GameSetting(
             subject = GameSubject.SPRING,
             level = GameLevel.EASY,

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameTest.kt
@@ -327,6 +327,52 @@ class GameTest() : DescribeSpec({
                 }
             }
         }
+        context("모든 플레이어가 준비되었는지 확인하면") {
+            context("대기 상태인 플레이어가 없으면") {
+                it("true를 반환한다.") {
+                    val game = Game(
+                        1L,
+                        type = PRIVATE,
+                        GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
+                        GameStatus.WAITING,
+                        Players(
+                            listOf(
+                                Player(1, HOST, PlayerStatus.JOINED),
+                                Player(2, GUEST, PlayerStatus.JOINED),
+                                Player(3, GUEST, PlayerStatus.JOINED),
+                                Player(4, GUEST, PlayerStatus.JOINED),
+                                Player(5, GUEST, PlayerStatus.JOINED)
+                            )
+                        ),
+                        InviteCode("ABC123")
+                    )
+
+                    game.isReady() shouldBe true
+                }
+            }
+            context("대기중인 사용자가 존재하면") {
+                it("false를 반환한다.") {
+                    val game = Game(
+                        1L,
+                        type = PRIVATE,
+                        GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
+                        GameStatus.WAITING,
+                        Players(
+                            listOf(
+                                Player(1, HOST, PlayerStatus.JOINED),
+                                Player(2, GUEST, PlayerStatus.JOINED),
+                                Player(3, GUEST, PlayerStatus.JOINED),
+                                Player(4, GUEST, PlayerStatus.WAITING),
+                                Player(5, GUEST, PlayerStatus.JOINED)
+                            )
+                        ),
+                        InviteCode("ABC123")
+                    )
+
+                    game.isReady() shouldBe false
+                }
+            }
+        }
         context("랜덤 게임을 생성하면") {
             it("랜덤 게임을 생성한다.") {
                 val game = Game.random(1L, GameSubject.JAVASCRIPT, listOf(1, 2, 3, 4, 5))

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameTest.kt
@@ -1,6 +1,8 @@
 package com.grepp.quizy.game.domain
 
-import com.grepp.quizy.game.domain.PlayerRole.*
+import com.grepp.quizy.game.domain.GameType.PRIVATE
+import com.grepp.quizy.game.domain.PlayerRole.GUEST
+import com.grepp.quizy.game.domain.PlayerRole.HOST
 import com.grepp.quizy.game.domain.exception.GameException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
@@ -31,7 +33,7 @@ class GameTest() : DescribeSpec({
             it("게임의 초대 코드는 6자리 문자열이다.") {
                 val game = Game.create(1L, GameSubject.JAVASCRIPT, 10, GameLevel.EASY, 1)
 
-                game.inviteCode.value.length shouldBe 6
+                game.inviteCode!!.value.length shouldBe 6
             }
         }
 
@@ -39,9 +41,11 @@ class GameTest() : DescribeSpec({
             it("참가한 유저를 게임에 추가한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    inviteCode = InviteCode("ABC123")
                 )
 
                 game.join(3)
@@ -51,9 +55,11 @@ class GameTest() : DescribeSpec({
             it("참가한 유저의 역할은 게스트이다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 game.join(3)
@@ -68,9 +74,11 @@ class GameTest() : DescribeSpec({
             it("게임에서 나간 유저를 게임에서 제거한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 game.quit(2)
@@ -82,9 +90,11 @@ class GameTest() : DescribeSpec({
             it("방장의 권한을 위임한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 game.quit(1)
@@ -99,9 +109,11 @@ class GameTest() : DescribeSpec({
             it("게임을 삭제한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 game.quit(1)
@@ -114,9 +126,11 @@ class GameTest() : DescribeSpec({
             it("강퇴된 사용자를 게임에서 제거한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 game.kick(1, 2)
@@ -129,9 +143,11 @@ class GameTest() : DescribeSpec({
             it("예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameHostPermissionException> {
@@ -145,9 +161,11 @@ class GameTest() : DescribeSpec({
             it("원하는 주제로 변경한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 game.updateSubject(1, GameSubject.SPRING)
@@ -160,9 +178,11 @@ class GameTest() : DescribeSpec({
             it("원하는 난이도로 변경한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 game.updateLevel(1, GameLevel.HARD)
@@ -175,9 +195,11 @@ class GameTest() : DescribeSpec({
             it("원하는 수로 변경한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 game.updateQuizCount(1, 20)
@@ -190,9 +212,11 @@ class GameTest() : DescribeSpec({
             it("게임에 참가하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.PLAYING,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameAlreadyStartedException> {
@@ -203,9 +227,11 @@ class GameTest() : DescribeSpec({
             it("강퇴하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.PLAYING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameAlreadyStartedException> {
@@ -216,9 +242,11 @@ class GameTest() : DescribeSpec({
             it("주제를 변경하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.PLAYING,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameAlreadyStartedException> {
@@ -228,9 +256,11 @@ class GameTest() : DescribeSpec({
             it("난이도를 변경하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.FINISHED,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameAlreadyStartedException> {
@@ -240,9 +270,11 @@ class GameTest() : DescribeSpec({
             it("퀴즈 수를 변경하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.DELETED,
-                    Players(listOf(Player(1, HOST)))
+                    Players(listOf(Player(1, HOST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameAlreadyStartedException> {
@@ -251,41 +283,73 @@ class GameTest() : DescribeSpec({
             }
         }
 
-        context("호스트가 아니면"){
-            it("주제를 변경하면 예외가 발생한다."){
+        context("호스트가 아니면") {
+            it("주제를 변경하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameHostPermissionException> {
                     game.updateSubject(2, GameSubject.SPRING)
                 }
             }
-            it("난이도를 변경하면 예외가 발생한다."){
+            it("난이도를 변경하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameHostPermissionException> {
                     game.updateLevel(2, GameLevel.HARD)
                 }
             }
-            it("퀴즈 수를 변경하면 예외가 발생한다."){
+            it("퀴즈 수를 변경하면 예외가 발생한다.") {
                 val game = Game(
                     1L,
+                    type = PRIVATE,
                     GameSetting(GameSubject.JAVASCRIPT, GameLevel.EASY, 10),
                     GameStatus.WAITING,
-                    Players(listOf(Player(1, HOST), Player(2, GUEST)))
+                    Players(listOf(Player(1, HOST), Player(2, GUEST))),
+                    InviteCode("ABC123")
                 )
 
                 shouldThrow<GameException.GameHostPermissionException> {
                     game.updateQuizCount(2, 20)
+                }
+            }
+        }
+        context("랜덤 게임을 생성하면") {
+            it("랜덤 게임을 생성한다.") {
+                val game = Game.random(1L, GameSubject.JAVASCRIPT, listOf(1, 2, 3, 4, 5))
+
+                game.type shouldBe GameType.RANDOM
+                game.setting.subject shouldBe GameSubject.JAVASCRIPT
+                game.players shouldBe Players(listOf(Player(1), Player(2), Player(3), Player(4), Player(5)))
+            }
+            it("랜덤 게임은 초대 코드가 없다.") {
+                val game = Game.random(1L, GameSubject.JAVASCRIPT, listOf(1, 2, 3, 4, 5))
+
+                game.inviteCode shouldBe null
+            }
+            it("랜덤 게임은 초기 설정이 있다.") {
+                val game = Game.random(1L, GameSubject.JAVASCRIPT, listOf(1, 2, 3, 4, 5))
+
+                game.setting.level shouldBe GameLevel.RANDOM
+            }
+            context("일정 인원이 아니라면") {
+                it("게임을 생성할 수 없다.") {
+                    shouldThrow<GameException.GameMisMatchNumberOfPlayersException> {
+                        Game.random(1L, GameSubject.JAVASCRIPT, listOf(1))
+                    }
                 }
             }
         }

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/GameTest.kt
@@ -345,6 +345,15 @@ class GameTest() : DescribeSpec({
 
                 game.setting.level shouldBe GameLevel.RANDOM
             }
+            it("랜덤 게임의 사용자는 대기 상태이다.") {
+                val game = Game.random(1L, GameSubject.JAVASCRIPT, listOf(1, 2, 3, 4, 5))
+
+                game.players.players[0].status shouldBe PlayerStatus.WAITING
+                game.players.players[1].status shouldBe PlayerStatus.WAITING
+                game.players.players[2].status shouldBe PlayerStatus.WAITING
+                game.players.players[3].status shouldBe PlayerStatus.WAITING
+                game.players.players[4].status shouldBe PlayerStatus.WAITING
+            }
             context("일정 인원이 아니라면") {
                 it("게임을 생성할 수 없다.") {
                     shouldThrow<GameException.GameMisMatchNumberOfPlayersException> {
@@ -354,6 +363,21 @@ class GameTest() : DescribeSpec({
             }
         }
 
+    }
+    describe("랜덤 게임에서") {
+        context("게임에 참가하면") {
+            it("참가상태로 변경한다.") {
+                val game = Game.random(1L, GameSubject.JAVASCRIPT, listOf(1, 2, 3, 4, 5))
+
+                game.joinRandomGame(1)
+
+                game.players.players[0].status shouldBe PlayerStatus.JOINED
+                game.players.players[1].status shouldBe PlayerStatus.WAITING
+                game.players.players[2].status shouldBe PlayerStatus.WAITING
+                game.players.players[3].status shouldBe PlayerStatus.WAITING
+                game.players.players[4].status shouldBe PlayerStatus.WAITING
+            }
+        }
     }
 
 }) {

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/PlayerTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/PlayerTest.kt
@@ -50,6 +50,15 @@ class PlayerTest() : DescribeSpec({
                 player1 shouldBe player2
             }
         }
+        context("게임에 참여하면") {
+            it("참여 상태로 변경한다.") {
+                val player = Player(1)
+
+                player.join()
+
+                player.status shouldBe PlayerStatus.JOINED
+            }
+        }
     }
 }) {
 }

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/PlayersTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/PlayersTest.kt
@@ -151,7 +151,60 @@ class PlayersTest() : DescribeSpec({
                 players.isEmpty() shouldBe true
             }
         }
+    }
 
+    describe("랜덤 게임 플레이어가") {
+        context("사용자가 게임에 참여하면") {
+            it("참여 상태로 변경한다.") {
+                val players = Players(
+                    listOf(
+                        Player(1, GUEST, PlayerStatus.WAITING),
+                        Player(2, GUEST, PlayerStatus.WAITING),
+                        Player(3, GUEST, PlayerStatus.WAITING),
+                        Player(4, GUEST, PlayerStatus.WAITING),
+                        Player(5, GUEST, PlayerStatus.WAITING)
+                    )
+                )
+
+                val updatedPlayers = players.joinRandomGame(1)
+
+                updatedPlayers.players[0].status shouldBe PlayerStatus.JOINED
+                updatedPlayers.players[1].status shouldBe PlayerStatus.WAITING
+                updatedPlayers.players[2].status shouldBe PlayerStatus.WAITING
+                updatedPlayers.players[3].status shouldBe PlayerStatus.WAITING
+                updatedPlayers.players[4].status shouldBe PlayerStatus.WAITING
+            }
+        }
+        context("이미 참여한 사용자가 참여하면") {
+            it("예외를 발생시킨다.") {
+                val players = Players(
+                    listOf(
+                        Player(1, GUEST, PlayerStatus.JOINED),
+                        Player(2, GUEST, PlayerStatus.WAITING),
+                        Player(3, GUEST, PlayerStatus.WAITING),
+                        Player(4, GUEST, PlayerStatus.WAITING),
+                        Player(5, GUEST, PlayerStatus.WAITING)
+                    )
+                )
+
+                shouldThrow<GameAlreadyParticipatedException> { players.joinRandomGame(1) }
+            }
+        }
+        context("참여목록에 없는 사용자가 참여하면") {
+            it("예외를 발생시킨다.") {
+                val players = Players(
+                    listOf(
+                        Player(1, GUEST, PlayerStatus.WAITING),
+                        Player(2, GUEST, PlayerStatus.WAITING),
+                        Player(3, GUEST, PlayerStatus.WAITING),
+                        Player(4, GUEST, PlayerStatus.WAITING),
+                        Player(5, GUEST, PlayerStatus.WAITING)
+                    )
+                )
+
+                shouldThrow<GameNotParticipatedException> { players.joinRandomGame(6) }
+            }
+        }
     }
 }) {
 }

--- a/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/PlayersTest.kt
+++ b/game-service/game-domain/src/test/kotlin/com/grepp/quizy/game/domain/PlayersTest.kt
@@ -205,6 +205,40 @@ class PlayersTest() : DescribeSpec({
                 shouldThrow<GameNotParticipatedException> { players.joinRandomGame(6) }
             }
         }
+        context("참여자의 참여여부를 확인하면") {
+            context("모두 참여했다면") {
+                it("참을 반환한다.") {
+                    val players = Players(
+                        listOf(
+                            Player(1, GUEST, PlayerStatus.JOINED),
+                            Player(2, GUEST, PlayerStatus.JOINED),
+                            Player(3, GUEST, PlayerStatus.JOINED),
+                            Player(4, GUEST, PlayerStatus.JOINED),
+                            Player(5, GUEST, PlayerStatus.JOINED)
+                        )
+                    )
+
+                    val isParticipated = players.isAllParticipated()
+                    isParticipated shouldBe true
+                }
+            }
+            context("대기중인 참여자가 있다면") {
+                it("거짓을 반환한다.") {
+                    val players = Players(
+                        listOf(
+                            Player(1, GUEST, PlayerStatus.JOINED),
+                            Player(2, GUEST, PlayerStatus.JOINED),
+                            Player(3, GUEST, PlayerStatus.JOINED),
+                            Player(4, GUEST, PlayerStatus.WAITING),
+                            Player(5, GUEST, PlayerStatus.JOINED)
+                        )
+                    )
+
+                    val isParticipated = players.isAllParticipated()
+                    isParticipated shouldBe false
+                }
+            }
+        }
     }
 }) {
 }

--- a/game-service/game-infra/build.gradle.kts
+++ b/game-service/game-infra/build.gradle.kts
@@ -13,6 +13,9 @@ dependencies {
     api(project(":infrastructure:kafka"))
     // Game Domain Module
     implementation(project(":game-service:game-domain"))
+    //open feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3")
+    implementation ("org.springframework.cloud:spring-cloud-commons:4.1.4")
     // H2 Database
     runtimeOnly("com.h2database:h2")
     // MySQL

--- a/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/feign/FeignConfig.kt
+++ b/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/feign/FeignConfig.kt
@@ -1,0 +1,27 @@
+package com.grepp.quizy.game.infra.feign
+
+import feign.codec.Encoder
+import feign.codec.ErrorDecoder
+import feign.form.spring.SpringFormEncoder
+import org.springframework.beans.factory.ObjectFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.cloud.openfeign.support.SpringEncoder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+@EnableFeignClients(basePackages = ["com.grepp.quizy.game.infra.feign"])
+class FeignConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(value = [ErrorDecoder::class])
+    fun commonFeignErrorDecoder(): FeignErrorDecoder = FeignErrorDecoder()
+
+    @Bean
+    fun encoder(converters: ObjectFactory<HttpMessageConverters>): Encoder =
+        SpringFormEncoder(SpringEncoder(converters))
+
+}

--- a/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/feign/FeignErrorDecoder.kt
+++ b/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/feign/FeignErrorDecoder.kt
@@ -1,0 +1,16 @@
+package com.grepp.quizy.game.infra.feign
+
+import feign.Response
+import feign.codec.ErrorDecoder
+
+class FeignErrorDecoder : ErrorDecoder {
+
+    override fun decode(p0: String?, p1: Response?): Exception {
+        return when(p1?.status()) {
+            400 -> IllegalArgumentException("Bad Request")
+            404 -> IllegalArgumentException("Not Found")
+            500 -> IllegalArgumentException("Internal Server Error")
+            else -> IllegalArgumentException("Unknown Error")
+        }
+    }
+}

--- a/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/feign/QuizFetcherFeignClient.kt
+++ b/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/feign/QuizFetcherFeignClient.kt
@@ -1,0 +1,22 @@
+package com.grepp.quizy.game.infra.feign
+
+import com.grepp.quizy.game.domain.GameLevel
+import com.grepp.quizy.game.domain.GameQuiz
+import com.grepp.quizy.game.domain.GameSubject
+import com.grepp.quizy.game.domain.QuizFetcher
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+// TODO: 퀴즈 서비스의 url 정해지면 추가
+@FeignClient(name = "quiz-fetcher", url = "\${quiz-service.url}")
+interface QuizFetcherFeignClient : QuizFetcher {
+
+    @GetMapping("/api/internal/search/quiz/game-set")
+    override fun fetchQuiz(
+        @RequestParam subject: GameSubject,
+        @RequestParam quizCount: Int,
+        @RequestParam level: GameLevel
+    ): GameQuiz
+
+}

--- a/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/game/GameRedisEntity.kt
+++ b/game-service/game-infra/src/main/kotlin/com/grepp/quizy/game/infra/game/GameRedisEntity.kt
@@ -15,18 +15,21 @@ class GameRedisEntity(
     @TimeToLive
     private val ttl: Long = HOURS_IN_SECOND,
 
+    val type: GameType,
+
     val setting: GameSetting,
 
     val status: GameStatus,
 
     val players: Players,
 
-    val inviteCode: InviteCode
+    val inviteCode: InviteCode?
 ) {
     companion object {
         fun from(game: Game): GameRedisEntity {
             return GameRedisEntity(
                 id = game.id,
+                type = game.type,
                 setting = game.setting,
                 status = game.status,
                 players = game.players,
@@ -39,6 +42,7 @@ class GameRedisEntity(
     fun toDomain(): Game {
         return Game(
             id = id,
+            type = type,
             _setting = setting,
             _status = status,
             _players = players,

--- a/game-service/game-infra/src/test/kotlin/com/grepp/quizy/game/infra/websocket/GameWebSocketMessageSenderTest.kt
+++ b/game-service/game-infra/src/test/kotlin/com/grepp/quizy/game/infra/websocket/GameWebSocketMessageSenderTest.kt
@@ -7,60 +7,60 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
-import java.security.Principal
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.security.Principal
 
 class GameWebSocketMessageSenderTest :
-        DescribeSpec({
-            val messageTemplate: SimpMessagingTemplate = mockk()
-            val messageSender =
-                    GameWebSocketMessageSender(messageTemplate)
+    DescribeSpec({
+        val messageTemplate: SimpMessagingTemplate = mockk()
+        val messageSender =
+            GameWebSocketMessageSender(messageTemplate)
 
-            describe("GameWebSocketMessageSender") {
-                context("메시지를 보내면") {
-                    val principal = mockk<Principal>()
-                    every { principal.name } returns "minhyeok"
-                    // Mock GameMessage 생성
-                    val mockGameSetting =
-                            GameSetting(
-                                    GameSubject.JAVASCRIPT,
-                                    GameLevel.EASY,
-                                    10,
-                            )
-                    val mockPlayers = Players(listOf())
-                    val mockInviteCode = InviteCode("ABC123")
+        describe("GameWebSocketMessageSender") {
+            context("메시지를 보내면") {
+                val principal = mockk<Principal>()
+                every { principal.name } returns "minhyeok"
+                // Mock GameMessage 생성
+                val mockGameSetting =
+                    GameSetting(
+                        GameSubject.JAVASCRIPT,
+                        GameLevel.EASY,
+                        10,
+                    )
+                val mockPlayers = Players(listOf())
+                val mockInviteCode = InviteCode("ABC123")
 
-                    val mockGamePayload =
-                            GamePayload(
-                                    setting = mockGameSetting,
-                                    status = GameStatus.WAITING,
-                                    players = mockPlayers,
-                                    inviteCode = mockInviteCode,
-                            )
+                val mockRoomPayload =
+                    RoomPayload(
+                        setting = mockGameSetting,
+                        status = GameStatus.WAITING,
+                        players = mockPlayers,
+                        inviteCode = mockInviteCode,
+                    )
 
-                    val message =
-                            GameMessage(
-                                    gameId = 1L,
-                                    type = MessageType.GAME_ROOM,
-                                    payload = mockGamePayload,
-                            )
-                    justRun {
+                val message =
+                    GameMessage(
+                        gameId = 1L,
+                        type = MessageType.GAME_ROOM,
+                        payload = mockRoomPayload,
+                    )
+                justRun {
+                    messageTemplate.convertAndSendToUser(
+                        any(),
+                        any(),
+                        any(),
+                    )
+                }
+                messageSender.send(principal, message)
+                it("메시지가 사용자에게 전달된다.") {
+                    verify {
                         messageTemplate.convertAndSendToUser(
-                                any(),
-                                any(),
-                                any(),
+                            "minhyeok",
+                            "/queue/quiz-grade",
+                            message,
                         )
-                    }
-                    messageSender.send(principal, message)
-                    it("메시지가 사용자에게 전달된다.") {
-                        verify {
-                            messageTemplate.convertAndSendToUser(
-                                    "minhyeok",
-                                    "/queue/quiz-grade",
-                                    message,
-                            )
-                        }
                     }
                 }
             }
-        })
+        }
+    })


### PR DESCRIPTION
<!-- PR의 제목은 "[Jira 티켓 코드] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세
랜덤매칭시 게임 입장 구현하였습니다.
게임 시작 전 세팅까지 하였습니다.
<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point
어쩌다보니까 Game 객체자체가 너무 커져버렸는데, 이거 조합으로 풀어내려고 했는데 조합으로 푸니까 Redis에 집어넣는게 문제더라구요.
그래서 그냥 Game객체 안에 모두 집어넣었는데 괜찮을지 모르겠습니다

그리고 어쩌다보니까 서비스가 계속 많이 생기게되는데 이래도 괜찮은건지..? 궁금합니다.
매칭시 인원이 모두 준비되면 시작하도록 하려고 해서 스프링 이벤트처리로 풀어내려고 했는데 이렇게 하니까 계속 클래스가 많아지는데 괜찮은지 한번 확인부탁드립니다.

그리고 내부 API 들에는 응답형태를 공통응답으로 하게 되면 로직내에서 공통응답을 풀어서 사용해야 될 것 같은데 어떻게 하는게 좋을 지 얘기 해봐야 될 것 같습니다 !

Feign 쪽 설정도 제대로 되었는지도 확인부탁드립니다 ㅎㅎ
<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점
계속 하다보니까 게임쪽에서 생각하지 못했던 개념들이 자꾸 튀어나와서 어지럽네요 ㅠㅠ
<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
