### PR TITLE
[QUZ-86][FEATURE] 안 푼 문제 검색 API 구현

### DIFF
--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/exception/QuizControllerAdvice.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/exception/QuizControllerAdvice.kt
@@ -4,7 +4,9 @@ import com.grepp.quizy.common.api.ApiResponse
 import com.grepp.quizy.common.exception.CustomException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -15,6 +17,8 @@ class QuizControllerAdvice {
     companion object {
         private const val UNKNOWN_ERROR_CODE = "INTERNAL_SERVER_ERROR"
         private const val UNKNOWN_ERROR_MESSAGE = "알 수 없는 서버 에러입니다"
+        private const val UNAUTHORIZED_ERROR_CODE = "UNAUTHORIZED"
+        private const val UNAUTHORIZED_ERROR_MESSAGE = "인증 정보가 필요합니다"
     }
 
     @ExceptionHandler(CustomException::class)
@@ -30,6 +34,19 @@ class QuizControllerAdvice {
                                     exception.message,
                             )
                     )
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingRequestHeaderException(
+        exception: MissingRequestHeaderException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<Unit>> =
+        ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(
+                ApiResponse.error(
+                    UNAUTHORIZED_ERROR_CODE,
+                    UNAUTHORIZED_ERROR_MESSAGE
+                )
+            )
 
     @ExceptionHandler(Exception::class)
     fun handleException(

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/QuizSearchApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/QuizSearchApi.kt
@@ -29,4 +29,18 @@ class QuizSearchApi(
                             )
                     )
             )
+
+    @GetMapping("/unanswered")
+    fun searchUnansweredByKeyword(
+        @RequestHeader("X-Auth-Id") userId: UserId,
+        params: UserSearchParams,
+    ): ApiResponse<SearchedQuizResponse> =
+        ApiResponse.success(
+            SearchedQuizResponse.from(
+                userQuizSearchUseCase.searchUnansweredByKeyword(
+                    userId,
+                    params.UserSearchCondition(),
+                )
+            )
+        )
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizMetadataCombiner.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizMetadataCombiner.kt
@@ -42,6 +42,22 @@ class QuizMetadataCombiner(
         }
     }
 
+    fun combineWithoutUserAnswer(userId: UserId, searchedQuizzes: Slice<Quiz>): List<QuizWithDetail> {
+        val quizIds = parseQuizIds(searchedQuizzes.content)
+        val counts = quizReader.readCounts(quizIds)
+
+        val likeStatus = likeManager.isLikedIn(userId, quizIds)
+
+        return searchedQuizzes.content.map { quiz ->
+            QuizDTOFactory.QuizWithDetail(
+                quiz,
+                counts.getCountOf(QuizId(quiz.id.value)),
+                likeStatus.isLikedBy(QuizId(quiz.id.value)),
+                null,
+            )
+        }
+    }
+
     private fun parseQuizIds(quizzes: List<Quiz>) =
             quizzes.map { QuizId(it.id.value) }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearchRepository.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearchRepository.kt
@@ -2,9 +2,12 @@ package com.grepp.quizy.quiz.domain.quizread
 
 import com.grepp.quizy.quiz.domain.global.dto.Slice
 import com.grepp.quizy.quiz.domain.quiz.Quiz
+import com.grepp.quizy.quiz.domain.quiz.QuizId
 
 interface QuizSearchRepository {
     fun search(condition: UserSearchCondition): Slice<Quiz>
+
+    fun searchNotIn(answeredQuizIds: List<QuizId>, condition: UserSearchCondition): Slice<Quiz>
 
     fun search(condition: GameQuizSearchCondition): List<Quiz>
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearcher.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearcher.kt
@@ -1,9 +1,14 @@
 package com.grepp.quizy.quiz.domain.quizread
 
+import com.grepp.quizy.quiz.domain.global.dto.Slice
+import com.grepp.quizy.quiz.domain.quiz.Quiz
+import com.grepp.quizy.quiz.domain.user.UserId
+import com.grepp.quizy.quiz.domain.useranswer.UserAnswerReader
 import org.springframework.stereotype.Component
 
 @Component
 class QuizSearcher(
+        private val userAnswerReader: UserAnswerReader,
         private val quizSearchRepository: QuizSearchRepository
 ) {
 
@@ -12,4 +17,9 @@ class QuizSearcher(
 
     fun search(condition: GameQuizSearchCondition) =
             quizSearchRepository.search(condition)
+
+    fun searchUnanswered(userId: UserId, condition: UserSearchCondition): Slice<Quiz> {
+        val answeredQuizIds = userAnswerReader.readAnswered(userId)
+        return quizSearchRepository.searchNotIn(answeredQuizIds, condition)
+    }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchService.kt
@@ -19,4 +19,11 @@ class UserQuizSearchService(
                 quizMetadataCombiner.combine(userId, searchedQuizzes)
         return Slice(content, searchedQuizzes.hasNext)
     }
+
+    override fun searchUnansweredByKeyword(userId: UserId, condition: UserSearchCondition): Slice<QuizWithDetail> {
+        val searchedQuizzes = quizSearcher.searchUnanswered(userId, condition)
+        val content =
+            quizMetadataCombiner.combineWithoutUserAnswer(userId, searchedQuizzes)
+        return Slice(content, searchedQuizzes.hasNext)
+    }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchUseCase.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchUseCase.kt
@@ -8,4 +8,6 @@ interface UserQuizSearchUseCase {
         userId: UserId?,
         condition: UserSearchCondition,
     ): Slice<QuizWithDetail>
+
+    fun searchUnansweredByKeyword(userId: UserId, condition: UserSearchCondition): Slice<QuizWithDetail>
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/useranswer/UserAnswerReader.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/useranswer/UserAnswerReader.kt
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Component
 class UserAnswerReader(private val repository: UserAnswerRepository) {
     fun read(userId: UserId, quizIds: List<QuizId>) =
         repository.findAllByUserAnswerId(quizIds.map { UserAnswerId(userId, it) })
+
+    fun readAnswered(userId: UserId) = repository.findAllByUserId(userId)
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/useranswer/UserAnswerRepository.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/useranswer/UserAnswerRepository.kt
@@ -1,8 +1,13 @@
 package com.grepp.quizy.quiz.domain.useranswer
 
+import com.grepp.quizy.quiz.domain.quiz.QuizId
+import com.grepp.quizy.quiz.domain.user.UserId
+
 interface UserAnswerRepository {
 
     fun save(userAnswer: UserAnswer): UserAnswer
 
     fun findAllByUserAnswerId(userAnswerIds: List<UserAnswerId>): UserAnswerPackage
+
+    fun findAllByUserId(userId: UserId): List<QuizId>
 }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/document/QuizDocument.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/document/QuizDocument.kt
@@ -45,6 +45,7 @@ class QuizDocument(
         val updatedAt: LocalDateTime,
 ) {
         companion object {
+                const val ID_FIELD = "id"
                 const val CONTENT_FIELD = "content"
                 const val CATEGORY_FIELD = "category.keyword"
                 const val TAG_FIELD = "tags"

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/CustomQuizSearchRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/CustomQuizSearchRepository.kt
@@ -12,6 +12,8 @@ interface CustomQuizSearchRepository {
             pageable: Pageable,
     ): Slice<QuizDocument>
 
+    fun searchNotIn(keyword: String, pageable: Pageable, quizIds: List<Long>): Slice<QuizDocument>
+
     fun searchAnswerableQuiz(
         category: String,
         difficulty: QuizDifficultyType,

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/QuizSearchRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/QuizSearchRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package com.grepp.quizy.quiz.infra.quizread.repository
 
 import com.grepp.quizy.quiz.domain.global.dto.Slice
 import com.grepp.quizy.quiz.domain.quiz.Quiz
+import com.grepp.quizy.quiz.domain.quiz.QuizId
 import com.grepp.quizy.quiz.domain.quizread.*
 import com.grepp.quizy.quiz.infra.quizread.document.QuizDomainFactory
 import com.grepp.quizy.quiz.infra.quizread.document.SortField
@@ -35,6 +36,20 @@ class QuizSearchRepositoryAdapter(
         return quizElasticRepository
             .searchAnswerableQuiz(condition.category, condition.difficulty, pageable)
             .map { QuizDomainFactory.toAnswerableQuiz(it) }
+    }
+
+    override fun searchNotIn(answeredQuizIds: List<QuizId>, condition: UserSearchCondition): Slice<Quiz> {
+        val pageable = convertPageable(condition)
+
+        return quizElasticRepository.searchNotIn(condition.field, pageable, answeredQuizIds.map { it.value })
+            .let { slice ->
+                Slice(
+                    slice.content.map {
+                        QuizDomainFactory.toQuiz(it)
+                    },
+                    slice.hasNext(),
+                )
+            }
     }
 
     private fun convertPageable(condition: SearchCondition) =

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/useranswer/repository/UserAnswerJpaRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/useranswer/repository/UserAnswerJpaRepository.kt
@@ -3,6 +3,9 @@ package com.grepp.quizy.quiz.infra.useranswer.repository
 import com.grepp.quizy.quiz.infra.useranswer.entity.UserAnswerEntity
 import com.grepp.quizy.quiz.infra.useranswer.entity.UserAnswerEntityId
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface UserAnswerJpaRepository :
-        JpaRepository<UserAnswerEntity, UserAnswerEntityId> {}
+interface UserAnswerJpaRepository : JpaRepository<UserAnswerEntity, UserAnswerEntityId> {
+        @Query("SELECT ua.id.quizId FROM UserAnswerEntity ua WHERE ua.id.userId = :userId")
+        fun findAllQuizIdByUserId(userId: Long): List<Long>
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/useranswer/repository/UserAnswerRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/useranswer/repository/UserAnswerRepositoryAdapter.kt
@@ -2,6 +2,7 @@ package com.grepp.quizy.quiz.infra.useranswer.repository
 
 import com.grepp.quizy.quiz.domain.quiz.QuizId
 import com.grepp.quizy.quiz.domain.quiz.QuizType
+import com.grepp.quizy.quiz.domain.user.UserId
 import com.grepp.quizy.quiz.domain.useranswer.*
 import com.grepp.quizy.quiz.infra.useranswer.entity.UserAnswerEntity
 import com.grepp.quizy.quiz.infra.useranswer.entity.UserAnswerEntityId
@@ -33,4 +34,7 @@ class UserAnswerRepositoryAdapter(
 
         return UserAnswerPackage(userAnswers)
     }
+
+    override fun findAllByUserId(userId: UserId): List<QuizId> =
+        userAnswerJpaRepository.findAllQuizIdByUserId(userId.value).map { QuizId(it) }
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Jira 티켓 코드] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

- 검색에서 "안 푼 문제만 보기" 관련 API 구현

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

`useranswer`에서 회원이 푼 퀴즈 ID 리스트를 조회하고, 
엘라스틱에서 해당 ID가 아닌 퀴즈만 조회하도록 구현했습니다. 이 플로우로 해도 괜찮을까요?

안 푼 문제 검색은 회원만 가능해야 해서 `ControllerAdvice`에 헤더 없는 케이스 예외 처리 추가했습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
