### PR TITLE
[QUZ-84][FEATURE] Quiz Image API 

### DIFF
--- a/gateway-service/src/main/kotlin/com/grepp/quizy/config/RedisConfig.kt
+++ b/gateway-service/src/main/kotlin/com/grepp/quizy/config/RedisConfig.kt
@@ -1,4 +1,4 @@
-package com.grepp.quizy.user.infra.redis.config
+package com.grepp.quizy.config
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/image/FileMapper.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/image/FileMapper.kt
@@ -1,0 +1,9 @@
+package com.grepp.quizy.quiz.api.image
+
+import com.grepp.quizy.quiz.domain.image.ImageFile
+import org.springframework.web.multipart.MultipartFile
+
+fun toImageFile(file: MultipartFile): ImageFile {
+    val contentType = file.contentType ?: throw IllegalArgumentException("File content type is null")
+    return ImageFile(contentType, file.inputStream)
+}

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/image/QuizImageApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/image/QuizImageApi.kt
@@ -1,0 +1,23 @@
+package com.grepp.quizy.quiz.api.image
+
+import com.grepp.quizy.common.api.ApiResponse
+import com.grepp.quizy.quiz.domain.image.QuizImage
+import com.grepp.quizy.quiz.domain.image.QuizImageService
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/quiz/images")
+class QuizImageApi(
+    private val quizImageService: QuizImageService
+) {
+
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun uploadImage(@RequestPart file: MultipartFile): ApiResponse<QuizImage> =
+        ApiResponse.success(quizImageService.uploadImage(toImageFile(file)))
+
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/ImageFile.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/ImageFile.kt
@@ -1,0 +1,10 @@
+package com.grepp.quizy.quiz.domain.image
+
+import java.io.InputStream
+
+data class ImageFile(
+    val contentType: String,
+    val inputStream: InputStream
+) {
+
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImage.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImage.kt
@@ -1,0 +1,12 @@
+package com.grepp.quizy.quiz.domain.image
+
+data class QuizImage(
+    val url: String,
+    val id: Long = 0,
+) {
+    companion object {
+        fun from(url: String): QuizImage {
+            return QuizImage(url)
+        }
+    }
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageManager.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageManager.kt
@@ -1,0 +1,21 @@
+package com.grepp.quizy.quiz.domain.image
+
+import com.grepp.quizy.quiz.domain.image.exception.QuizImageDomainException
+import org.springframework.stereotype.Component
+
+@Component
+class QuizImageManager(
+    private val quizImageRepository: QuizImageRepository
+) {
+    fun append(image: QuizImage): QuizImage {
+        return quizImageRepository.save(image)
+    }
+
+    fun read(id: Long): QuizImage {
+        return quizImageRepository.findById(id) ?: throw QuizImageDomainException.NotFound
+    }
+
+    fun delete(id: Long) {
+        quizImageRepository.deleteById(id)
+    }
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageRepository.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageRepository.kt
@@ -1,0 +1,11 @@
+package com.grepp.quizy.quiz.domain.image
+
+interface QuizImageRepository {
+
+    fun save(image: QuizImage): QuizImage
+
+    fun findById(id: Long): QuizImage?
+
+    fun deleteById(id: Long)
+
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageService.kt
@@ -1,0 +1,15 @@
+package com.grepp.quizy.quiz.domain.image
+
+import org.springframework.stereotype.Service
+
+@Service
+class QuizImageService(
+    private val quizImageUploader: QuizImageUploader,
+    private val quizImageAppender: QuizImageManager
+) {
+
+    fun uploadImage(imageFile: ImageFile): QuizImage {
+        val quizImage = quizImageUploader.upload(imageFile)
+        return quizImageAppender.append(quizImage)
+    }
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageUploader.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/QuizImageUploader.kt
@@ -1,0 +1,5 @@
+package com.grepp.quizy.quiz.domain.image
+
+interface QuizImageUploader {
+    fun upload(imageFile: ImageFile): QuizImage
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/exception/QuizImageDomainException.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/exception/QuizImageDomainException.kt
@@ -1,0 +1,12 @@
+package com.grepp.quizy.quiz.domain.image.exception
+
+import com.grepp.quizy.common.exception.DomainException
+
+sealed class QuizImageDomainException(
+    errorCode: QuizImageErrorCode
+) : DomainException(errorCode) {
+
+    data object NotFound : QuizImageDomainException(QuizImageErrorCode.IMAGE_NOT_FOUND_ERROR) {
+        private fun readResolve(): Any = NotFound
+    }
+}

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/exception/QuizImageErrorCode.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/image/exception/QuizImageErrorCode.kt
@@ -1,0 +1,16 @@
+package com.grepp.quizy.quiz.domain.image.exception
+
+import com.grepp.quizy.common.exception.BaseErrorCode
+import com.grepp.quizy.common.exception.ErrorReason
+
+enum class QuizImageErrorCode(
+    private val status: Int,
+    private val errorCode: String,
+    private val message: String,
+) : BaseErrorCode {
+    IMAGE_UPLOAD_ERROR(500, "FILE_500_1", "이미지 업로드 중 오류가 발생했습니다"),
+    IMAGE_NOT_FOUND_ERROR(404, "FILE_404_1", "해당 ID의 이미지가 없습니다");
+
+    override val errorReason: ErrorReason
+        get() = ErrorReason.of(status, errorCode, message)
+}

--- a/quiz-service/quiz-infra/build.gradle.kts
+++ b/quiz-service/quiz-infra/build.gradle.kts
@@ -23,6 +23,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("mysql:mysql-connector-java:8.0.28")
 
+    //gcs
+    implementation("org.springframework.cloud", "spring-cloud-gcp-starter", "1.2.5.RELEASE")
+    implementation("org.springframework.cloud", "spring-cloud-gcp-storage", "1.2.5.RELEASE")
+
     implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
 
     //redis

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/gcs/config/GcsConfig.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/gcs/config/GcsConfig.kt
@@ -1,0 +1,37 @@
+package com.grepp.quizy.quiz.infra.gcs.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageOptions
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.util.*
+
+@Configuration
+class GcsConfig(
+    @Value("\${spring.cloud.gcp.storage.credentials.encoded-key}")
+    private val gcpKey: String,
+    @Value("\${spring.cloud.gcp.storage.project-id}")
+    private val projectId: String
+) {
+
+    @Bean
+    @Throws(IOException::class)
+    fun storage(): Storage {
+        val credentials: GoogleCredentials = getDecodedCredentials(gcpKey)
+        return StorageOptions.newBuilder()
+            .setProjectId(projectId)
+            .setCredentials(credentials)
+            .build()
+            .service
+    }
+
+    @Throws(IOException::class)
+    private fun getDecodedCredentials(encodedKey: String?): GoogleCredentials {
+        val decodedKey = Base64.getDecoder().decode(encodedKey)
+        return GoogleCredentials.fromStream(ByteArrayInputStream(decodedKey))
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/FileGcsUploader.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/FileGcsUploader.kt
@@ -1,0 +1,43 @@
+package com.grepp.quizy.quiz.infra.image
+
+import com.google.cloud.storage.BlobInfo
+import com.google.cloud.storage.Storage
+import com.grepp.quizy.quiz.domain.image.ImageFile
+import com.grepp.quizy.quiz.domain.image.QuizImage
+import com.grepp.quizy.quiz.domain.image.QuizImageUploader
+import com.grepp.quizy.quiz.infra.image.exception.QuizImageInfraException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.io.IOException
+import java.nio.channels.Channels
+import java.util.*
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class FileGcsUploader(
+    private val storage: Storage,
+    @Value("\${spring.cloud.gcp.storage.bucket}")
+    private val bucketName: String,
+    @Value("\${spring.cloud.gcp.storage.url}")
+    private val storagePath: String
+) : QuizImageUploader {
+    override fun upload(imageFile: ImageFile): QuizImage {
+        val uuid = UUID.randomUUID().toString()
+        val blobInfo: BlobInfo =
+            BlobInfo.newBuilder(bucketName, uuid).setContentType(imageFile.contentType).build()
+        try {
+            storage.writer(blobInfo).use { writer ->
+                imageFile.inputStream.use { input ->
+                    input.transferTo(Channels.newOutputStream(writer))
+                    log.info { "이미지 업로드 성공 - ${storagePath + uuid}" }
+                    return QuizImage.from(storagePath + uuid)
+                }
+            }
+        } catch (e: IOException) {
+            log.error { "이미지 업로드 실패" }
+            throw QuizImageInfraException.UploadError
+        }
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/entity/QuizImageEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/entity/QuizImageEntity.kt
@@ -1,0 +1,30 @@
+package com.grepp.quizy.quiz.infra.image.entity
+
+import com.grepp.quizy.quiz.domain.image.QuizImage
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "quiz_image")
+class QuizImageEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    val url: String
+) {
+
+    companion object {
+        fun from(domain: QuizImage): QuizImageEntity{
+            return QuizImageEntity(
+                id = domain.id,
+                url = domain.url
+            )
+        }
+    }
+
+    fun toDomain(): QuizImage {
+        return QuizImage(
+            id = id,
+            url = url
+        )
+    }
+
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/exception/QuizImageInfraException.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/exception/QuizImageInfraException.kt
@@ -1,0 +1,14 @@
+package com.grepp.quizy.quiz.infra.image.exception
+
+import com.grepp.quizy.common.exception.InfraException
+import com.grepp.quizy.quiz.domain.image.exception.QuizImageErrorCode
+
+sealed class QuizImageInfraException(
+    errorCode: QuizImageErrorCode
+) : InfraException(errorCode) {
+
+    data object UploadError :
+        QuizImageInfraException(QuizImageErrorCode.IMAGE_UPLOAD_ERROR) {
+        private fun readResolve(): Any = UploadError
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/repository/QuizImageJpaRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/repository/QuizImageJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.grepp.quizy.quiz.infra.image.repository
+
+import com.grepp.quizy.quiz.infra.image.entity.QuizImageEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface QuizImageJpaRepository : JpaRepository<QuizImageEntity, Long> {
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/repository/QuizImageRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/image/repository/QuizImageRepositoryAdapter.kt
@@ -1,0 +1,27 @@
+package com.grepp.quizy.quiz.infra.image.repository
+
+import com.grepp.quizy.quiz.domain.image.QuizImage
+import com.grepp.quizy.quiz.domain.image.QuizImageRepository
+import com.grepp.quizy.quiz.infra.image.entity.QuizImageEntity
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+@Transactional
+class QuizImageRepositoryAdapter(
+    private val quizImageJpaRepository: QuizImageJpaRepository
+) : QuizImageRepository {
+
+    override fun save(image: QuizImage): QuizImage {
+        return quizImageJpaRepository.save(QuizImageEntity.from(image)).toDomain()
+    }
+
+    override fun findById(id: Long): QuizImage? {
+        return quizImageJpaRepository.findByIdOrNull(id)?.toDomain()
+    }
+
+    override fun deleteById(id: Long) {
+        quizImageJpaRepository.deleteById(id)
+    }
+}

--- a/quiz-service/quiz-infra/src/main/resources/application-infra.yml
+++ b/quiz-service/quiz-infra/src/main/resources/application-infra.yml
@@ -20,6 +20,15 @@ spring:
 #    org.hibernate.SQL: debug
 #    org.hibernate.type.descriptor.sql: trace
 
+  cloud:
+    gcp:
+      storage:
+        url: https://storage.googleapis.com/${BUCKET_NAME}/
+        credentials:
+          encoded-key: ${GCS_KEY}
+        project-id: ${GCP_PROJECT_ID}
+        bucket: ${BUCKET_NAME}
+
 shedlock:
   name: like_sync_lock
 


### PR DESCRIPTION
<!-- PR의 제목은 "[Jira 티켓 코드] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

먼저 MultipartFile만 받는 API를 만들어서 해당 파일을 GCS에 업로드하고 ID를 반환합니다.
이 ID를 Quiz를 만들때 QuizImageId로 해서 같이 보냅니다. 

이렇게 만든 이유는 멀티파트파일이 네트워크 비용이 많이 들어가기때문에 유저가 퀴즈 생성 페이지에서 파일을 등록함과 동시에 API를 호출해 ID를 받아갑니다. 이후 퀴즈 생성버튼을 누르면 Image ID들을 같이 보내주도록합니다

멀티파트파일은 도메인 모듈로 못내려가기 때문에 적절히 변환해주어야하는데 GCS에 업로드할때는 inputstream과 contentType만 있으면 되기때문에 해당 데이터들을 가지고있는 DTO로 변환하여 도메인 모듈로 내립니다

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
