### PR TITLE
[QUZ-87][FEATURE] Swagger 인증 및 UserPrincipal 커스텀 어노테이션 구현

### DIFF
--- a/common/common-web/build.gradle.kts
+++ b/common/common-web/build.gradle.kts
@@ -1,0 +1,12 @@
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+}
+
+tasks.bootJar {
+    enabled = false
+}
+
+tasks.jar {
+    enabled = true
+}

--- a/common/common-web/src/main/kotlin/com/grepp/quizy/web/annotation/AuthUser.kt
+++ b/common/common-web/src/main/kotlin/com/grepp/quizy/web/annotation/AuthUser.kt
@@ -1,0 +1,5 @@
+package com.grepp.quizy.web.annotation
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AuthUser

--- a/common/common-web/src/main/kotlin/com/grepp/quizy/web/config/WebCommonAutoConfig.kt
+++ b/common/common-web/src/main/kotlin/com/grepp/quizy/web/config/WebCommonAutoConfig.kt
@@ -1,0 +1,15 @@
+package com.grepp.quizy.web.config
+
+import com.grepp.quizy.web.resolver.UserPrincipalArgumentResolver
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+class WebCommonAutoConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(UserPrincipalArgumentResolver())
+    }
+}

--- a/common/common-web/src/main/kotlin/com/grepp/quizy/web/dto/UserPrincipal.kt
+++ b/common/common-web/src/main/kotlin/com/grepp/quizy/web/dto/UserPrincipal.kt
@@ -1,0 +1,6 @@
+package com.grepp.quizy.web.dto
+
+data class UserPrincipal(
+    val value: Long
+) {
+}

--- a/common/common-web/src/main/kotlin/com/grepp/quizy/web/resolver/UserPrincipalArgumentResolver.kt
+++ b/common/common-web/src/main/kotlin/com/grepp/quizy/web/resolver/UserPrincipalArgumentResolver.kt
@@ -1,0 +1,31 @@
+package com.grepp.quizy.web.resolver
+
+import com.grepp.quizy.web.annotation.AuthUser
+import com.grepp.quizy.web.dto.UserPrincipal
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import java.lang.RuntimeException
+
+class UserPrincipalArgumentResolver : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(AuthUser::class.java) &&
+                parameter.parameterType == UserPrincipal::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        val request = webRequest.getNativeRequest(HttpServletRequest::class.java)
+        val userId = request?.getHeader("X-Auth-Id")
+            ?: throw RuntimeException("Authorization header is missing")
+
+        return UserPrincipal(userId.toLong())
+    }
+}

--- a/common/common-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/common-web/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.grepp.quizy.web.config.WebCommonAutoConfig

--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/global/config/SwaggerConfig.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/global/config/SwaggerConfig.kt
@@ -1,4 +1,4 @@
-package com.grepp.quizy.user.config
+package com.grepp.quizy.game.api.global.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.models.Components
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration
 @OpenAPIDefinition(
         info =
                 io.swagger.v3.oas.annotations.info.Info(
-                        title = "User API",
+                        title = "Game API",
                         version = "v1",
                 )
 )

--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/global/config/WebConfig.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/global/config/WebConfig.kt
@@ -1,0 +1,35 @@
+package com.grepp.quizy.game.api.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry
+                .addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods(
+                        "DELETE",
+                        "GET",
+                        "POST",
+                        "PATCH",
+                        "PUT",
+                )
+                .allowedHeaders(
+                        "Access-Control-Allow-Headers",
+                        "Access-Control-Allow-Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers",
+                        "Origin",
+                        "Cache-Control",
+                        "Content-Type",
+                        "Authorization",
+                        "X-Auth-Id",
+                )
+                .exposedHeaders("*") // CORS 응답에 대해 클라이언트가 접근할수있도록 허용
+                .allowCredentials(true)
+                .maxAge(3600)
+    }
+}

--- a/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/global/exception/GlobalExceptionHandler.kt
+++ b/game-service/game-application/app-api/src/main/kotlin/com/grepp/quizy/game/api/global/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,41 @@
+package com.grepp.quizy.game.api.global.exception
+
+import com.grepp.quizy.common.api.ApiResponse
+import com.grepp.quizy.common.exception.CustomException
+import com.grepp.quizy.common.exception.ErrorReason
+import com.grepp.quizy.game.domain.exception.GameException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException::class)
+    protected fun handleGameException(
+            e: GameException,
+            request: HttpServletRequest,
+    ): ApiResponse<Unit> {
+        return ApiResponse.error(
+                e.errorCode.errorReason,
+                request.requestURI,
+                e.message,
+        )
+    }
+
+    @ExceptionHandler(Exception::class)
+    protected fun handleException(
+            e: Exception,
+            request: HttpServletRequest,
+    ): ApiResponse<Unit> {
+        return ApiResponse.error(
+                ErrorReason.of(
+                        500,
+                        "INTERNAL_SERVER_ERROR",
+                        "Internal Server Error",
+                ),
+                request.requestURI,
+                e.message ?: "Internal Server Error",
+        )
+    }
+}

--- a/matching-service/matching-application/app-api/src/main/kotlin/com/grepp/quizy/matching/config/SwaggerConfig.kt
+++ b/matching-service/matching-application/app-api/src/main/kotlin/com/grepp/quizy/matching/config/SwaggerConfig.kt
@@ -1,7 +1,12 @@
 package com.grepp.quizy.matching.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.headers.Header
+import io.swagger.v3.oas.models.media.StringSchema
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,8 +20,39 @@ import org.springframework.context.annotation.Configuration
                 )
 )
 class SwaggerConfig {
+
     @Bean
-    fun openApi(): OpenAPI {
-        return OpenAPI().addServersItem(Server().url("/matching"))
+    fun openAPI(): OpenAPI {
+        // Bearer 토큰 인증 스키마 설정
+        val securityScheme = SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .`in`(SecurityScheme.In.HEADER)
+            .name("Authorization")
+
+        // 토큰 요구사항 설정
+        val securityRequirement = SecurityRequirement()
+            .addList("bearerAuth")
+
+        // x-auth-id 헤더 설정을 포함한 Components 구성
+        val components = Components()
+            .addSecuritySchemes("bearerAuth", securityScheme)
+            .addHeaders(
+                "x-auth-id", Header()
+                    .description("사용자 ID (게이트웨이에서 자동 추가)")
+                    .schema(StringSchema())
+            )
+
+        return OpenAPI()
+            .components(components)
+            .security(listOf(securityRequirement))  // Arrays.asList 대신 listOf 사용
+            .addServersItem(Server().url("/"))
+            .info(
+                io.swagger.v3.oas.models.info.Info()
+                    .title("게이트웨이 API 문서")
+                    .description("게이트웨이에서 JWT 토큰을 검증하고 x-auth-id 헤더를 자동으로 추가합니다")
+                    .version("1.0")
+            )
     }
 }

--- a/quiz-service/quiz-application/app-api/build.gradle.kts
+++ b/quiz-service/quiz-application/app-api/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 dependencies {
+    implementation(project(":common:common-web"))
     implementation(project(":quiz-service:quiz-domain"))
     implementation(project(":quiz-service:quiz-infra"))
 

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/config/SwaggerConfig.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/config/SwaggerConfig.kt
@@ -1,6 +1,7 @@
-package com.grepp.quizy.user.config
+package com.grepp.quizy.quiz.api.global.config
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.headers.Header
@@ -12,13 +13,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@OpenAPIDefinition(
-        info =
-                io.swagger.v3.oas.annotations.info.Info(
-                        title = "User API",
-                        version = "v1",
-                )
-)
+@OpenAPIDefinition(info = Info(title = "Quiz API", version = "v1"))
 class SwaggerConfig {
 
     @Bean

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/config/WebConfig.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/config/WebConfig.kt
@@ -1,0 +1,35 @@
+package com.grepp.quizy.quiz.api.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry
+                .addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods(
+                        "DELETE",
+                        "GET",
+                        "POST",
+                        "PATCH",
+                        "PUT",
+                )
+                .allowedHeaders(
+                        "Access-Control-Allow-Headers",
+                        "Access-Control-Allow-Origin",
+                        "Access-Control-Request-Method",
+                        "Access-Control-Request-Headers",
+                        "Origin",
+                        "Cache-Control",
+                        "Content-Type",
+                        "Authorization",
+                        "X-Auth-Id",
+                )
+                .exposedHeaders("*") // CORS 응답에 대해 클라이언트가 접근할수있도록 허용
+                .allowCredentials(true)
+                .maxAge(3600)
+    }
+}

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/LikeApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/like/LikeApi.kt
@@ -3,6 +3,8 @@ package com.grepp.quizy.quiz.api.like
 import com.grepp.quizy.common.api.ApiResponse
 import com.grepp.quizy.quiz.api.like.dto.LikeRequest
 import com.grepp.quizy.quiz.domain.like.LikeService
+import com.grepp.quizy.web.annotation.AuthUser
+import com.grepp.quizy.web.dto.UserPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,9 +16,12 @@ class LikeApi(private val likeService: LikeService) {
 
     @PostMapping
     fun toggleLike(
+            @AuthUser principal: UserPrincipal,
             @RequestBody request: LikeRequest
     ): ApiResponse<Boolean> =
             ApiResponse.success(
                     likeService.toggleLike(request.toLike())
-            )
+            ).also {
+                println("User ${principal.value} toggled like on quiz ${request.quizId}")
+            }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include("gateway-service")
 
 include("common")
 include("common:common-jpa")
+include("common:common-web")
 
 include("quiz-service")
 include("quiz-service:quiz-infra")
@@ -28,12 +29,6 @@ include("matching-service:matching-infra")
 include("matching-service:matching-domain")
 include("matching-service:matching-application")
 include("matching-service:matching-application:app-api")
-
-include("search-service")
-include("search-service:search-infra")
-include("search-service:search-domain")
-include("search-service:search-application")
-include("search-service:search-application:app-api")
 
 include("infrastructure:kafka")
 

--- a/user-service/user-infra/src/main/resources/application-infra.yml
+++ b/user-service/user-infra/src/main/resources/application-infra.yml
@@ -4,13 +4,13 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://localhost:3306/quizy?useSSL=false&allowPublicKeyRetrieval=true
-    username: root
-    password: 1234
+    url: jdbc:mysql://localhost:3306/${DATABASE_NAME}?useSSL=false&allowPublicKeyRetrieval=true
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show-sql: true


### PR DESCRIPTION
<!-- PR의 제목은 "[Jira 티켓 코드] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

기존에 @RequestHeader()를 사용해서 뽑아오는 방식은 조금 별로라는 생각이 들어서  커스텀어노테이션을 제작했습니다
제가 추가한 common-web 모듈을 의존성 주입해주시고 컨트롤러에서 

```kotlin
@PostMapping
    fun toggleLike(
            @AuthUser principal: UserPrincipal,
            @RequestBody request: LikeRequest
    )
...
```

이런식으로 사용하시면 됩니다!


## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
