### PR TITLE
[QUZ-114][FEATURE] 실시간 인기 검색어 API 구현

### DIFF
--- a/infrastructure/docker-compose/es/docker-compose.yml
+++ b/infrastructure/docker-compose/es/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     ports:
       - '9200:9200'
       - '9300:9300'
+    networks:
+      - ${GLOBAL_NETWORK:-app-tier}
 
   kibana:
     container_name: kibana
@@ -28,5 +30,7 @@ services:
       ELASTICSEARCH_HOSTS: http://es:9200
     ports:
       - 5601:5601
+    networks:
+      - ${GLOBAL_NETWORK:-app-tier}
     depends_on:
       - es

--- a/infrastructure/docker-compose/logstash/logstash.json
+++ b/infrastructure/docker-compose/logstash/logstash.json
@@ -1,86 +1,16 @@
 {
   "index_patterns": ["logstash-*"],
+  "priority": 200,
   "template": {
     "settings": {
-      "number_of_shards": 1,
-      "analysis": {
-        "tokenizer": {
-          "my_nori_tokenizer": {
-            "type": "nori_tokenizer",
-            "decompound_mode": "mixed",
-            "discard_punctuation": false
-          },
-          "my_ngram_tokenizer": {
-            "type": "ngram",
-            "min_gram": 1,
-            "max_gram": 3,
-            "token_chars": [
-              "letter",
-              "digit"
-            ]
-          }
-        },
-        "filter": {
-          "stopwords": {
-            "type": "stop",
-            "stopwords": "_english_"
-          }
-        },
-        "analyzer": {
-          "my_nori_analyzer": {
-            "type": "custom",
-            "tokenizer": "my_nori_tokenizer",
-            "filter": [
-              "lowercase",
-              "stop",
-              "trim",
-              "stopwords",
-              "nori_part_of_speech"
-            ],
-            "char_filter": [
-              "html_strip"
-            ]
-          },
-          "my_ngram_analyzer": {
-            "type": "custom",
-            "tokenizer": "my_ngram_tokenizer",
-            "filter": [
-              "lowercase",
-              "stop",
-              "trim",
-              "stopwords",
-              "nori_part_of_speech"
-            ],
-            "char_filter": [
-              "html_strip"
-            ]
-          }
-        }
-      }
+      "number_of_shards": 1
     },
     "mappings": {
       "properties": {
         "keyword": {
-          "type": "text",
-          "analyzer": "my_nori_analyzer",
-          "fields": {
-            "keyword": {
-              "type": "keyword"
-
-            },
-            "nori": {
-              "type": "text",
-              "analyzer": "my_nori_analyzer"
-            },
-            "ngram": {
-              "type": "text",
-              "analyzer": "my_ngram_analyzer"
-            }
-          }
+          "type": "keyword"
         }
       }
     }
-  },
-  "priority": 200,
-  "version": 1
+  }
 }

--- a/infrastructure/docker-compose/logstash/pipeline/logstash.conf
+++ b/infrastructure/docker-compose/logstash/pipeline/logstash.conf
@@ -1,8 +1,7 @@
 input {
-  file {
-    path => "/var/log/nginx/access_json.log"
-    type => nginx
-    codec => json
+  tcp {
+      port => 5044       # Spring Boot의 Logback에서 보낸 포트
+      codec => json_lines # JSON 형식으로 수신
   }
 }
 
@@ -12,12 +11,6 @@ filter {
     source => "request-parameter"
     field_split => "&"
   }
-
-  ruby {
-    init => 'require "time"'
-    code => 'event.set("time_kst", Time.parse(event.get("time")).localtime("+09:00").strftime("%Y.%m.%d"))'
-  }
-
 
   # keyword 값 디코드
   # 이 부분은 kv 필터로 추출된 필드 이름에 따라 달라질 수 있습니다.
@@ -29,9 +22,13 @@ filter {
 }
 
 output {
+  stdout {              # 콘솔 출력 (테스트용)
+    codec => rubydebug
+  }
+
   elasticsearch {
                 hosts => ["es:9200"]
-                index => "logstash-%{time_kst}"
+                index => "logstash-%{+YYYY.MM.dd}"
                 manage_template => true
         	template => "/usr/share/logstash/logstash.json"
         	template_name => "logstash"

--- a/infrastructure/docker-compose/logstash/pipeline/logstash.conf
+++ b/infrastructure/docker-compose/logstash/pipeline/logstash.conf
@@ -6,19 +6,11 @@ input {
 }
 
 filter {
-  # request-parameter 필드에서 키-값 쌍을 파싱
-  kv {
-    source => "request-parameter"
-    field_split => "&"
-  }
-
-  # keyword 값 디코드
-  # 이 부분은 kv 필터로 추출된 필드 이름에 따라 달라질 수 있습니다.
-  # 예를 들어, kv 필터가 keyword 필드를 생성하면, 아래와 같이 사용합니다.
-  urldecode {
-    charset => "UTF-8"
-    field => "keyword"
-  }
+  if [message] =~ /^API Request/ {
+      grok {
+        match => { "message" => "API Request .*keyword:\s*(?<keyword>\S+)" }
+      }
+    }
 }
 
 output {

--- a/infrastructure/docker-compose/logstash/pipeline/logstash.conf
+++ b/infrastructure/docker-compose/logstash/pipeline/logstash.conf
@@ -1,20 +1,28 @@
 input {
   tcp {
-      port => 5044       # Spring Boot의 Logback에서 보낸 포트
-      codec => json_lines # JSON 형식으로 수신
+      port => 5044
+      codec => json_lines
   }
 }
 
 filter {
   if [message] =~ /^API Request/ {
-      grok {
-        match => { "message" => "API Request .*keyword:\s*(?<keyword>\S+)" }
-      }
+    grok {
+      match => { "message" => "API Request .*keyword:\s*(?<keyword>[^}]+)(?:\s+page|$)" }
     }
+
+    mutate {
+      split => { "keyword" => "," }
+    }
+
+    mutate {
+      strip => ["keyword"]
+    }
+  }
 }
 
 output {
-  stdout {              # 콘솔 출력 (테스트용)
+  stdout {
     codec => rubydebug
   }
 

--- a/quiz-service/quiz-application/app-api/build.gradle.kts
+++ b/quiz-service/quiz-application/app-api/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
 
     //swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+
+    // logback
+    implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 }
 
 tasks.named<BootJar>("bootJar") {

--- a/quiz-service/quiz-application/app-api/build.gradle.kts
+++ b/quiz-service/quiz-application/app-api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(project(":quiz-service:quiz-infra"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
     //swagger

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/log/ApiLoggingAspect.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/log/ApiLoggingAspect.kt
@@ -1,0 +1,33 @@
+package com.grepp.quizy.quiz.api.global.log
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class ApiLoggingAspect(private val request: HttpServletRequest) {
+    private val log = KotlinLogging.logger {}
+
+    @Pointcut("@annotation(com.grepp.quizy.quiz.api.global.log.LogApi)")
+    fun logApi() {}
+
+    @Before("logApi()")
+    fun logBefore() {
+        val params = request.parameterNames
+        val uri = request.requestURI
+        val logMessage = StringBuilder("API Request $uri { params:  { ")
+
+        while (params.hasMoreElements()) {
+            val name = params.nextElement()
+            val value = request.getParameter(name)
+            logMessage.append(name).append(": ").append(value).append(" ")
+        }
+        logMessage.append(" }").append(" }")
+
+        log.info { logMessage.toString() }
+    }
+}

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/log/LogApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/global/log/LogApi.kt
@@ -1,0 +1,5 @@
+package com.grepp.quizy.quiz.api.global.log
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LogApi

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/QuizSearchApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/QuizSearchApi.kt
@@ -3,6 +3,7 @@ package com.grepp.quizy.quiz.api.quizread
 import com.grepp.quizy.common.api.ApiResponse
 import com.grepp.quizy.quiz.api.global.log.LogApi
 import com.grepp.quizy.quiz.api.quizread.dto.UserSearchParams
+import com.grepp.quizy.quiz.api.quizread.dto.TrendingKeywordResponse
 import com.grepp.quizy.quiz.api.quizread.dto.QuizSliceResponse
 import com.grepp.quizy.quiz.domain.quizread.UserQuizSearchUseCase
 import com.grepp.quizy.quiz.domain.user.UserId
@@ -46,6 +47,14 @@ class QuizSearchApi(
                     UserId(principal.value),
                     params.UserSearchCondition(),
                 )
+            )
+        )
+
+    @GetMapping("/trending")
+    fun searchTrendingKeyword(): ApiResponse<TrendingKeywordResponse> =
+        ApiResponse.success(
+            TrendingKeywordResponse(
+                keywords = userQuizSearchUseCase.searchTrendingKeyword()
             )
         )
 }

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/QuizSearchApi.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/QuizSearchApi.kt
@@ -1,6 +1,7 @@
 package com.grepp.quizy.quiz.api.quizread
 
 import com.grepp.quizy.common.api.ApiResponse
+import com.grepp.quizy.quiz.api.global.log.LogApi
 import com.grepp.quizy.quiz.api.quizread.dto.UserSearchParams
 import com.grepp.quizy.quiz.api.quizread.dto.QuizSliceResponse
 import com.grepp.quizy.quiz.domain.quizread.UserQuizSearchUseCase
@@ -18,6 +19,7 @@ class QuizSearchApi(
         private val userQuizSearchUseCase: UserQuizSearchUseCase
 ) {
 
+    @LogApi
     @GetMapping
     fun searchByKeyword(
         @RequestHeader("X-Auth-Id") userId: UserId?,
@@ -32,6 +34,7 @@ class QuizSearchApi(
                     )
             )
 
+    @LogApi
     @GetMapping("/unanswered")
     fun searchUnansweredByKeyword(
         @AuthUser principal: UserPrincipal,

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/dto/Request.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/dto/Request.kt
@@ -9,14 +9,14 @@ import com.grepp.quizy.quiz.domain.quizread.QuizSortType
 import com.grepp.quizy.quiz.domain.quizread.UserSearchCondition
 
 data class UserSearchParams(
-        val keyword: String,
+        val keyword: List<String>,
         val page: Int = 0,
         val size: Int = 0,
         val sort: QuizSortType = QuizSortType.TRENDING,
 ) {
     fun UserSearchCondition() =
             UserSearchCondition(
-                    field = keyword,
+                    fields = keyword,
                     page = Page(page, size),
                     sort = sort,
             )

--- a/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/dto/Response.kt
+++ b/quiz-service/quiz-application/app-api/src/main/kotlin/com/grepp/quizy/quiz/api/quizread/dto/Response.kt
@@ -26,6 +26,6 @@ data class QuizFeedResponse(
     }
 }
 
-data class GameSetResponse(
-    val quizzes: List<GameQuizDetail>
-)
+data class TrendingKeywordResponse(val keywords: List<String>)
+
+data class GameSetResponse(val quizzes: List<GameQuizDetail>)

--- a/quiz-service/quiz-application/app-api/src/main/resources/application.yml
+++ b/quiz-service/quiz-application/app-api/src/main/resources/application.yml
@@ -25,6 +25,10 @@ spring:
 server:
   port: 8083
 
+logstash:
+  host: localhost
+  port: 5044
+
 springdoc:
   api-docs:
     version: openapi_3_1
@@ -36,6 +40,11 @@ spring:
   config:
     activate:
       on-profile: dev
+
+logstash:
+  host: ${LOGSTASH_HOST}
+  port: ${LOGSTASH_PORT}
+
 springdoc:
   api-docs:
     version: openapi_3_1

--- a/quiz-service/quiz-application/app-api/src/main/resources/logback-spring.xml
+++ b/quiz-service/quiz-application/app-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,21 @@
+<configuration>
+    <springProperty name="LOGSTASH_HOST" source="logstash.host" defaultValue="localhost" />
+    <springProperty name="LOGSTASH_PORT" source="logstash.port" defaultValue="5044" />
+
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} %level %thread --- [%5thread] %logger{36} : %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="LOGSTASH"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearchRepository.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearchRepository.kt
@@ -21,4 +21,6 @@ interface QuizSearchRepository {
     fun searchNotIn(condition: FeedSearchCondition): Slice<Quiz>
 
     fun search(condition: GameQuizSearchCondition): List<Quiz>
+
+    fun searchTrendingKeyword(): List<String>
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearcher.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearcher.kt
@@ -33,5 +33,5 @@ class QuizSearcher(
     }
 
     fun searchTrendingKeyword(): List<String> =
-        quizSearchRepository.searchTrendingKeyword()
+        quizSearchRepository.searchTrendingKeyword().map { "#$it" }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearcher.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/QuizSearcher.kt
@@ -31,4 +31,7 @@ class QuizSearcher(
     fun searchByCategory(condition: FeedSearchCondition): Slice<Quiz> {
         return quizSearchRepository.searchNotIn(condition)
     }
+
+    fun searchTrendingKeyword(): List<String> =
+        quizSearchRepository.searchTrendingKeyword()
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/SearchCondition.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/SearchCondition.kt
@@ -18,7 +18,7 @@ enum class QuizSortType {
 }
 
 data class UserSearchCondition(
-    val field: String,
+    val fields: List<String>,
     private val page: Page,
     val sort: QuizSortType,
 ) : SearchCondition {

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizReadService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizReadService.kt
@@ -38,5 +38,8 @@ class UserQuizReadService(
         return QuizFeed(feedCondition.interest!!, Slice(content, searchedQuizzes.hasNext))
     }
 
-    private fun findUserInterest(userId: UserId) = quizUserReader.read(userId).interests.random()
+    private fun findUserInterest(userId: UserId): QuizCategory {
+        val user = quizUserReader.read(userId)
+        return if (user.interests.isEmpty()) QuizCategory.entries.random() else user.interests.random()
+    }
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchService.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchService.kt
@@ -26,4 +26,7 @@ class UserQuizSearchService(
             quizMetadataCombiner.combineWithoutUserAnswer(userId, searchedQuizzes)
         return Slice(content, searchedQuizzes.hasNext)
     }
+
+    override fun searchTrendingKeyword(): List<String> =
+        quizSearcher.searchTrendingKeyword()
 }

--- a/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchUseCase.kt
+++ b/quiz-service/quiz-domain/src/main/kotlin/com/grepp/quizy/quiz/domain/quizread/UserQuizSearchUseCase.kt
@@ -10,4 +10,6 @@ interface UserQuizSearchUseCase {
     ): Slice<QuizWithDetail>
 
     fun searchUnansweredByKeyword(userId: UserId, condition: UserSearchCondition): Slice<QuizWithDetail>
+
+    fun searchTrendingKeyword(): List<String>
 }

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/document/LogDocument.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/document/LogDocument.kt
@@ -1,0 +1,39 @@
+package com.grepp.quizy.quiz.infra.log.document
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
+import java.time.LocalDateTime
+
+@Document(indexName = "logstash-*")
+class LogDocument(
+    @Id
+    val id: String,
+
+    @Field(type = FieldType.Date)
+    val timestamp: LocalDateTime,
+
+    @Field(type = FieldType.Keyword)
+    val level: String,
+
+    @Field(type = FieldType.Text)
+    val message: String,
+
+    @Field(type = FieldType.Keyword)
+    val threadName: String,
+
+    @Field(type = FieldType.Keyword)
+    val loggerName: String,
+
+    @Field(type = FieldType.Integer)
+    val levelValue: Int,
+
+    @Field(type = FieldType.Keyword)
+    val keyword: String?
+) {
+
+    companion object {
+        const val KEYWORD_FIELD = "keyword"
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/repository/CustomLogSearchRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/repository/CustomLogSearchRepository.kt
@@ -1,0 +1,6 @@
+package com.grepp.quizy.quiz.infra.log.repository
+
+interface CustomLogSearchRepository {
+
+    fun topKKeyword(k: Int): List<String>
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/repository/CustomLogSearchRepositoryImpl.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/repository/CustomLogSearchRepositoryImpl.kt
@@ -1,0 +1,71 @@
+package com.grepp.quizy.quiz.infra.log.repository
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders
+import co.elastic.clients.json.JsonData
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregation
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.data.elasticsearch.core.SearchHits
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Repository
+class CustomLogSearchRepositoryImpl(
+    private val elasticsearchOperations: ElasticsearchOperations
+) : CustomLogSearchRepository {
+
+    override fun topKKeyword(k: Int): List<String> {
+        val aggregation = Aggregation.of { agg ->
+            agg.terms { terms ->
+                terms.field("keyword")
+                    .size(k)
+            }
+        }
+
+        val query = NativeQueryBuilder()
+            .withQuery(
+                QueryBuilders.bool()
+                    .must(
+                        QueryBuilders.match().query("/api/quiz/search").field("message").build()._toQuery()
+                    )
+                    .must(rangeQuery())
+                    .build()
+                    ._toQuery()
+            )
+            .withAggregation("top_keywords", aggregation)
+            .build()
+
+        val result = elasticsearchOperations.search(query, Map::class.java, IndexCoordinates.of("logstash-*"))
+
+        return parseAggregationResult(result)
+    }
+
+    private fun rangeQuery(): Query {
+        val now = LocalDateTime.now()
+        val startOfDay = now.toLocalDate().atStartOfDay()
+        val endOfDay = now.toLocalDate().atTime(23, 59, 59, 999000000)
+
+        val startOfDayMillis = startOfDay.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val endOfDayMillis = endOfDay.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+        return QueryBuilders.range()
+            .field("@timestamp")
+            .gte(JsonData.of(startOfDayMillis))
+            .lte(JsonData.of(endOfDayMillis))
+            .build()
+            ._toQuery()
+    }
+
+    private fun parseAggregationResult(result: SearchHits<Map<*, *>>): List<String> {
+        val aggregationResult = (result.aggregations.aggregations() as? ArrayList<*>)?.get(0) as ElasticsearchAggregation
+        return aggregationResult
+            .aggregation().aggregate
+            .sterms().buckets()
+            .array()
+            .map { it.key().stringValue() }
+    }
+}

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/repository/LogElasticRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/log/repository/LogElasticRepository.kt
@@ -1,0 +1,8 @@
+package com.grepp.quizy.quiz.infra.log.repository
+
+import com.grepp.quizy.quiz.infra.log.document.LogDocument
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
+
+interface LogElasticRepository :
+    ElasticsearchRepository<LogDocument, String>,
+    CustomLogSearchRepository

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/CustomQuizSearchRepository.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/CustomQuizSearchRepository.kt
@@ -9,12 +9,12 @@ import org.springframework.data.domain.Slice
 interface CustomQuizSearchRepository {
 
     fun search(
-            keyword: String,
+            keywords: List<String>,
             pageable: Pageable,
     ): Slice<QuizDocument>
 
     fun searchNotIn(
-        keyword: String,
+        keyword: List<String>,
         pageable: Pageable,
         quizIds: List<Long>
     ): Slice<QuizDocument>

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/CustomQuizSearchRepositoryImpl.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/CustomQuizSearchRepositoryImpl.kt
@@ -34,12 +34,12 @@ class CustomQuizSearchRepositoryImpl(
             )
 
     override fun search(
-            keyword: String,
-            pageable: Pageable,
+        keywords: List<String>,
+        pageable: Pageable,
     ): Slice<QuizDocument> {
         val query =
                 QueryBuilders.multiMatch()
-                        .query(keyword)
+                        .query(keywords.joinToString(" "))
                         .fields(keywordSearchFields)
                         .build()
                         ._toQuery()
@@ -53,11 +53,11 @@ class CustomQuizSearchRepositoryImpl(
         return convertToSlice(nativeQuery, pageable)
     }
 
-    override fun searchNotIn(keyword: String, pageable: Pageable, quizIds: List<Long>): Slice<QuizDocument> {
+    override fun searchNotIn(keywords: List<String>, pageable: Pageable, quizIds: List<Long>): Slice<QuizDocument> {
         val query = QueryBuilders.bool()
             .must(
                 QueryBuilders.multiMatch()
-                    .query(keyword)
+                    .query(keywords.joinToString(" "))
                     .fields(keywordSearchFields)
                     .build()
                     ._toQuery()

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/QuizSearchRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/QuizSearchRepositoryAdapter.kt
@@ -38,7 +38,7 @@ class QuizSearchRepositoryAdapter(
         val pageable = convertPageable(condition)
 
         return quizElasticRepository
-                .search(condition.field, pageable)
+                .search(condition.fields, pageable)
                 .let { slice ->
                     Slice(
                             slice.content.map {
@@ -60,7 +60,7 @@ class QuizSearchRepositoryAdapter(
     override fun searchNotIn(answeredQuizIds: List<QuizId>, condition: UserSearchCondition): Slice<Quiz> {
         val pageable = convertPageable(condition)
 
-        return quizElasticRepository.searchNotIn(condition.field, pageable, answeredQuizIds.map { it.value })
+        return quizElasticRepository.searchNotIn(condition.fields, pageable, answeredQuizIds.map { it.value })
             .let { slice ->
                 Slice(
                     slice.content.map {

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/QuizSearchRepositoryAdapter.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/quizread/repository/QuizSearchRepositoryAdapter.kt
@@ -4,6 +4,7 @@ import com.grepp.quizy.quiz.domain.global.dto.Slice
 import com.grepp.quizy.quiz.domain.quiz.Quiz
 import com.grepp.quizy.quiz.domain.quiz.QuizId
 import com.grepp.quizy.quiz.domain.quizread.*
+import com.grepp.quizy.quiz.infra.log.repository.LogElasticRepository
 import com.grepp.quizy.quiz.infra.quizread.document.QuizDocument
 import com.grepp.quizy.quiz.infra.quizread.document.QuizDomainFactory
 import com.grepp.quizy.quiz.infra.quizread.document.SortField
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Repository
 @Repository
 class QuizSearchRepositoryAdapter(
         private val quizElasticRepository: QuizElasticRepository,
+    private val logElasticRepository: LogElasticRepository
 ) : QuizSearchRepository {
 
     override fun save(quiz: Quiz) {
@@ -95,6 +97,10 @@ class QuizSearchRepositoryAdapter(
                     slice.hasNext(),
                 )
             }
+    }
+
+    override fun searchTrendingKeyword(): List<String> {
+        return logElasticRepository.topKKeyword(10)
     }
 
     private fun convertPageable(condition: SearchCondition) =

--- a/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/user/entity/QuizUserEntity.kt
+++ b/quiz-service/quiz-infra/src/main/kotlin/com/grepp/quizy/quiz/infra/user/entity/QuizUserEntity.kt
@@ -31,7 +31,7 @@ class QuizUserEntity(
     }
 
     fun toDomain(): QuizUser {
-        return QuizUser(UserId(id), name, imgPath)
+        return QuizUser(UserId(id), name, imgPath, interests.map { it.interest }.toMutableList())
     }
 
     fun update(name: String, imgPath: String) {


### PR DESCRIPTION
<!-- PR의 제목은 "[Jira 티켓 코드] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

- 실시간 인기 검색 태그 API
- Spring - Logstash - ElasticSearch 파이프라인 연결

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

> logback 설정을 통해 logstash로 로그를 tcp 전송합니다.
> 해당 로그는 elasticsearch에 일별 로그 인덱스에 저장되고,
> 실시간 인기 검색 요청 시 오늘자 로그 데이터에서 상위 10개의 키워드를 응답합니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
